### PR TITLE
Update buildModel.m

### DIFF
--- a/MASH-FRET/source/simulations/buildModel.m
+++ b/MASH-FRET/source/simulations/buildModel.m
@@ -60,7 +60,6 @@ if K>1 && isTrans
 %             P = kx*N; // M.CAS Hadzic 2012
 %             P = double(~~(kx)); %  M.CAS Hadzic 2014, to be updated
             P = kx.*expT; % simple rate-to-prob-model for Markov chains, 2018-03-12 RB
-            i = 1;
             for i=1:K 
                 %P(:,i) = (kx(:,i)./sum(kx,2)(i))*(1-exp(-sum(kx,2)(i)*expT));
                 P(i,i) = 1 - sum(kx(i,:))*expT; % simple rate-to-prob-model for Markov chains
@@ -69,10 +68,8 @@ if K>1 && isTrans
             % State probabilities from rates.
             [V,D,W]=eig(P);
             D = diag(D);
-            i = 1;
             for i=1:K
                 if round(1e5*real(D(i)))/1e5==1 && round(imag(D(i)))==0 
-                    disp(i)
                     break   
                 end
             end
@@ -82,7 +79,6 @@ if K>1 && isTrans
 %             P = kx*N; // M.CAS Hadzic 2012
 %             P = double(~~(kx)); %  M.CAS Hadzic 2014, to be updated
             P = kx.*expT; % simple rate-to-prob-model for Markov chains, 2018-03-12 RB
-            i= 1;
             for i=1:K 
                  %P(:,i) = (kx(:,i)./sum(kx,2)(i))*(1-exp(-sum(kx,2)(i)*expT));
                  P(i,i) = 1 - sum(kx(i,:))*expT; % simple rate-to-prob-model for Markov chains, 2018-03-12 RB
@@ -90,7 +86,6 @@ if K>1 && isTrans
             % State probabilities from rates, 2018-03-12 RB PlosOne
             [V,D,W]=eig(P);
             D = diag(D);
-            i = 1;
             for i=1:K
                 if round(1e5*real(D(i)))/1e5==1 && round(imag(D(i)))==0 
                     %disp(i) % control, 2018-03-12 RB
@@ -203,7 +198,7 @@ if K>1 && isTrans
                 mix{n}(1,1+end_t/expT:N) = -1;
             end
             
-            setContPan(['trace n:°' num2str(n) ' completed'], 'process',...
+            setContPan(['trace n:Â°' num2str(n) ' completed'], 'process',...
                 h_fig);
             n = n+1;
         end
@@ -246,7 +241,7 @@ else
             discr_seq{n}(1+end_t/expT:N,:) = -1;
             mix{n}(1,1+end_t/expT:N) = -1;
         end
-        setContPan(['trace n:°' num2str(n) ' completed'], 'process', ...
+        setContPan(['trace n:Â°' num2str(n) ' completed'], 'process', ...
             h_fig);
     end
 end

--- a/MASH-FRET/source/simulations/buildModel.m
+++ b/MASH-FRET/source/simulations/buildModel.m
@@ -57,23 +57,48 @@ if K>1 && isTrans
     while n <= n_max
         if n==1 && ~imp_kx
             kx = kx(1:K,1:K);
-%             P = kx*N;
-            P = double(~~(kx)); % to be updated
-%             i= 1;
-%             for i=1:K 
-%                 P(:,i) = (kx(:,i)./sum(kx,2)(i))*(1-exp(-sum(kx,2)(i)*expT));
-%                 P(i,i) = exp(-sum(kx,2)(i)*expT);
-%             end 
+%             P = kx*N; // M.CAS Hadzic 2012
+%             P = double(~~(kx)); %  M.CAS Hadzic 2014, to be updated
+            P = kx.*expT; % simple rate-to-prob-model for Markov chains, 2018-03-12 RB
+            i = 1;
+            for i=1:K 
+                %P(:,i) = (kx(:,i)./sum(kx,2)(i))*(1-exp(-sum(kx,2)(i)*expT));
+                P(i,i) = 1 - sum(kx(i,:))*expT; % simple rate-to-prob-model for Markov chains
+            end
+            
+            % State probabilities from rates.
+            [V,D,W]=eig(P);
+            D = diag(D);
+            i = 1;
+            for i=1:K
+                if round(1e5*real(D(i)))/1e5==1 && round(imag(D(i)))==0 
+                    disp(i)
+                    break   
+                end
+            end
+            Prob = W(:,i)./sum(W(:,i));
         elseif imp_kx
             kx = kx_all(1:K,1:K,n);
-%             P = kx*N;
-            P = double(~~(kx)); % to be updated
-%             i= 1;
-%             for i=1:K 
-%                 P(:,i) = (kx(:,i)./sum(kx,2)(i))*(1-exp(-sum(kx,2)(i)*expT));
-%                 P(i,i) = exp(-sum(kx,2)(i)*expT);
-%             end 
-        end
+%             P = kx*N; // M.CAS Hadzic 2012
+%             P = double(~~(kx)); %  M.CAS Hadzic 2014, to be updated
+            P = kx.*expT; % simple rate-to-prob-model for Markov chains, 2018-03-12 RB
+            i= 1;
+            for i=1:K 
+                 %P(:,i) = (kx(:,i)./sum(kx,2)(i))*(1-exp(-sum(kx,2)(i)*expT));
+                 P(i,i) = 1 - sum(kx(i,:))*expT; % simple rate-to-prob-model for Markov chains, 2018-03-12 RB
+            end
+            % State probabilities from rates, 2018-03-12 RB PlosOne
+            [V,D,W]=eig(P);
+            D = diag(D);
+            i = 1;
+            for i=1:K
+                if round(1e5*real(D(i)))/1e5==1 && round(imag(D(i)))==0 
+                    %disp(i) % control, 2018-03-12 RB
+                    break   
+                end
+            end
+            Prob = W(:,i)./sum(W(:,i));
+         end
         
         if bleach
             end_t = ceil(random('exp',bleachT));
@@ -92,8 +117,12 @@ if K>1 && isTrans
             stes = zeros(K,N);
             
             % pick a "first state" randomly with uniform probabilities
-            s_curr = randsample(1:K, 1, true, ones(1,K));
+            %s_curr = randsample(1:K, 1, true, double(~~(kx))); % M.CAS Hadzic 2014
             
+            % pick a "first state" randomly weighted with state
+            % propabilities 
+            s_curr = randsample(1:K, 1, true, Prob); % 2018-03-12, RB PlosOne
+          
             while t<end_t
 
                 curr_f = ceil(t/expT);
@@ -105,9 +134,15 @@ if K>1 && isTrans
                 
                 s_prev = s_curr; % previous state
                 
-                % pick a "first state" randomly with k-based probabilities
-                s_curr = randsample(1:K, 1, true, double(~~P(s_prev,:)));
-
+                % pick a "next state" randomly with uniform probabilities
+                %s_curr = randsample(1:K, 1, true, double(~~P(s_prev,:)));
+                
+                % pick a "next state" randomly with P-based probabilities
+                %s_curr = randsample(1:K, 1, true, P(s_prev,:));
+                
+                % pick a "next state" randomly with k-based probabilities
+                s_curr = randsample(1:K, 1, true, kx(s_prev,:)/sum(kx(s_prev,:)));
+                
                 % pick a "first state" randomly with defined probabilities
 %                 s_curr = randsample(1:K, 1, true, pdef(s_prev,:));
                 


### PR DESCRIPTION
MASH-FRET - Simulation tool

Error fixes:
- State transition determination. Probability matrix has been adjusted to the actual rate matrix. This is in accordance with R.Börner, PLOSOne, 2018. doi:10.1371/journal.pone.0195277 .
- Initial state probability has been adjusted to the actual state population. This is in accordance with R.Börner, PLOSOne, 2018. doi:10.1371/journal.pone.0195277 .

