### PR TITLE
MATLAB toolbox requirements for MASH-FRET

### DIFF
--- a/MASH-FRET/.release_version.json
+++ b/MASH-FRET/.release_version.json
@@ -1,4 +1,4 @@
 {
 "tag" : "1.1.2",
-"prev_commit_hash" : "c94ff27"
+"prev_commit_hash" : "660d36b"
 }

--- a/MASH-FRET/.release_version.json
+++ b/MASH-FRET/.release_version.json
@@ -1,4 +1,4 @@
 {
 "tag" : "1.1.2",
-"prev_commit_hash" : "b28632f"
+"prev_commit_hash" : "c94ff27"
 }

--- a/MASH-FRET/.release_version.json
+++ b/MASH-FRET/.release_version.json
@@ -1,4 +1,4 @@
 {
 "tag" : "1.1.2",
-"prev_commit_hash" : "660d36b"
+"prev_commit_hash" : "f555a87"
 }

--- a/MASH-FRET/.release_version.json
+++ b/MASH-FRET/.release_version.json
@@ -1,4 +1,4 @@
 {
 "tag" : "1.1.2",
-"prev_commit_hash" : "23836c3"
+"prev_commit_hash" : "b28632f"
 }

--- a/MASH-FRET/.release_version.json
+++ b/MASH-FRET/.release_version.json
@@ -1,4 +1,4 @@
 {
 "tag" : "1.1.2",
-"prev_commit_hash" : "f555a87"
+"prev_commit_hash" : "4156f7a"
 }

--- a/MASH-FRET/requirements.md
+++ b/MASH-FRET/requirements.md
@@ -1,0 +1,5 @@
+MATLAB
+Symbolic Math Toolbox
+Image Processing Toolbox
+Statistics and Machine Learning Toolbox
+Curve Fitting Toolbox

--- a/MASH-FRET/tools/check_dependencies.m
+++ b/MASH-FRET/tools/check_dependencies.m
@@ -28,7 +28,7 @@ switch mode
         for i = 1:length(files)
             filelist{i} = [files(i).folder,'\', files(i).name];
         end
-
+        [~,pList] = matlab.codetools.requiredFilesAndProducts(filelist);
         fprintf('The following toolboxes are required to run MASH-FRET:\n');
         for i = 1:length(pList)
            fprintf('- %s (version installed %s)\n', pList(i).Name, pList(i).Version);

--- a/MASH-FRET/tools/check_dependencies.m
+++ b/MASH-FRET/tools/check_dependencies.m
@@ -67,7 +67,7 @@ switch mode
             end
         end
         if error == 0
-            fprintf('-> Sucess: All required toolboxes are installed\n')
+            fprintf('-> Success: All required toolboxes are installed\n')
         else
             fprintf('-> Warning: Not all required toolboxes are installed. Parts of MASH-FRET may not function properly\n')
         end

--- a/MASH-FRET/tools/check_dependencies.m
+++ b/MASH-FRET/tools/check_dependencies.m
@@ -1,0 +1,77 @@
+function check_dependencies(mode)
+% Check toolbox dependencies of MASH-FRET
+
+% Input Arguments
+% Discovery mode: find required toolboxes among the installed ones and writes them to a file requirements.md
+%                 Note 1: run check_dependencies.m in Discovery mode only on an installation where all toolboxes are available, otherwise the list may be incomplete)
+%                 Note 2: Running check_dependencies.m in Discovery mode requires MATLAB >2014a
+% Analysis mode: check whether the required toolboxes (specified in requirements.md) are installed on the current system)
+
+root = fileparts(which('MASH'));
+if isempty(root)
+    fprintf('MASH-FRET root not found!');
+    return
+end
+requirementsFile = [root, '/requirements.md'];
+
+switch mode
+    case 'discovery'
+    
+        if verLessThan('matlab', '8.3')
+            fprintf('Discovery mode requires MATLAB version > 2014a. You may still run check_dependencies.m in analysis mode')
+            return
+        end
+       
+        filepath = [root, '/**/*.m'];
+        files = dir(filepath);
+        filelist = cell(1, length(files));
+        for i = 1:length(files)
+            filelist{i} = [files(i).folder,'\', files(i).name];
+        end
+
+        fprintf('The following toolboxes are required to run MASH-FRET:\n');
+        for i = 1:length(pList)
+           fprintf('- %s (version installed %s)\n', pList(i).Name, pList(i).Version);
+        end
+        fprintf('- %s (version installed %s)\n', pList(i).Name, pList(i).Version);
+        fprintf('\nNote: only toolboxes that are required and installed are listed.\nRun Discovery mode only on full installations (all toolboxes present).\ncheck_dependencies.m will list those that are required\n')
+
+        if ~exist(requirementsFile, 'file')
+            fileID = fopen(requirementsFile,'w');
+            fprintf(fileID, '');
+            for i = 1:length(pList)
+                fprintf(fileID, '%s\n', pList(i).Name);
+            end
+            fclose(fileID);
+        else
+            fprintf('Note: requirements.md already exists.\n')
+        end
+
+        
+    case 'analysis'
+        if ~exist(requirementsFile, 'file')
+            fprintf('Error: requirements.md file does not exist\n')
+            return
+        end
+        
+        fid = fopen(requirementsFile);
+        requirementsContent = textscan(fid,'%s', 'delimiter','\n');
+        product_info = ver;
+        error = 0;
+        for i = 1:length(requirementsContent{1})
+            if ismember(requirementsContent{1}{i}, {product_info.Name})
+                fprintf('- %s is available\n', requirementsContent{1}{i})
+            else
+                fprintf('- %s is missing\n', requirementsContent{1}{i})
+                error = 1;
+            end
+        end
+        if error == 0
+            fprintf('-> Sucess: All required toolboxes are installed\n')
+        else
+            fprintf('-> Warning: Not all required toolboxes are installed. Parts of MASH-FRET may not function properly\n')
+        end
+end
+
+
+end

--- a/MASH-FRET/tools/check_dependencies.m
+++ b/MASH-FRET/tools/check_dependencies.m
@@ -4,7 +4,7 @@ function check_dependencies(mode)
 % Input Arguments
 % Discovery mode: find required toolboxes among the installed ones and writes them to a file requirements.md
 %                 Note 1: run check_dependencies.m in Discovery mode only on an installation where all toolboxes are available, otherwise the list may be incomplete)
-%                 Note 2: Running check_dependencies.m in Discovery mode requires MATLAB >2014a
+%                 Note 2: Running check_dependencies.m in Discovery mode requires MATLAB >2016b
 % Analysis mode: check whether the required toolboxes (specified in requirements.md) are installed on the current system)
 
 root = fileparts(which('MASH'));
@@ -17,8 +17,8 @@ requirementsFile = [root, '/requirements.md'];
 switch mode
     case 'discovery'
     
-        if verLessThan('matlab', '8.3')
-            fprintf('Discovery mode requires MATLAB version > 2014a. You may still run check_dependencies.m in analysis mode')
+        if verLessThan('matlab', '9.1')
+            fprintf('Discovery mode requires MATLAB version > 2016b. You may still run check_dependencies.m in analysis mode')
             return
         end
        
@@ -26,7 +26,7 @@ switch mode
         files = dir(filepath);
         filelist = cell(1, length(files));
         for i = 1:length(files)
-            filelist{i} = [files(i).folder,'\', files(i).name];
+            filelist{i} = fullfile(files(i).folder,files(i).name);
         end
         [~,pList] = matlab.codetools.requiredFilesAndProducts(filelist);
         fprintf('The following toolboxes are required to run MASH-FRET:\n');

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Clone or download MASH-FRET into a directory of your choice.
 ```
 git clone https://github.com/RNA-FRETools/MASH-FRET.git
 ```
-Within Matlab, add MASH-FRET to you path by going to `Home → Set Path → Add with Subfolders`
+Within Matlab, add MASH-FRET to your path by going to `Home → Set Path → Add with Subfolders`
 
 **Note:** *MASH-FRET is tested to run under Matlab version R2011a and above*
 

--- a/docs/System_requirements.md
+++ b/docs/System_requirements.md
@@ -1,0 +1,18 @@
+---
+layout: default
+title: System requirements
+nav_order: 9
+---
+
+# System requirements
+
+MASH-FRET requires the following MATLAB toolboxes:
+- Symbolic Math Toolbox
+- Image Processing Toolbox
+- Statistics and Machine Learning Toolbox
+- Curve Fitting Toolbox
+
+To check whether these toolboxes are installed on your system, run the following line from the MATLAB command prompt
+```
+check_dependencies('analysis')
+```

--- a/docs/System_requirements.md
+++ b/docs/System_requirements.md
@@ -6,7 +6,9 @@ nav_order: 9
 
 # System requirements
 
-MASH-FRET requires the following MATLAB toolboxes:
+MASH-FRET is tested to run under MATLAB 7.12 (2011a) and above.
+
+MASH-FRET additionally requires the following MATLAB toolboxes:
 - Symbolic Math Toolbox
 - Image Processing Toolbox
 - Statistics and Machine Learning Toolbox

--- a/docs/System_requirements.md
+++ b/docs/System_requirements.md
@@ -14,6 +14,8 @@ MASH-FRET additionally requires the following MATLAB toolboxes:
 - Statistics and Machine Learning Toolbox
 - Curve Fitting Toolbox
 
+Add MASH-FRET to your path by going to `Home → Set Path → Add with Subfolders`
+
 To check whether these toolboxes are installed on your system, run the following line from the MATLAB command prompt
 ```
 check_dependencies('analysis')


### PR DESCRIPTION
Added a function MASH-FRET/tools/check_dependencies.m that checks the toolbox requirements of MASH-FRET
 check_dependencies.m can be run in two different ways: discovery and analysis mode
- discovery mode detects the required toolboxes amongst all installed ones and writes them to a file requirements.md 
- analysis mode checks whether a set of dependencies (toolboxes specified in requirements.md) is matched

The file docs/System_requirements.md is updated with the corresponding information. 