### PR TITLE
Fix pre-commit hook to fetch the latest lightweight tag

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-tag_commit_hash=`git describe --always`
+tag_commit_hash=`git describe --always --tags`
 tag=`echo $tag_commit_hash | cut -d'-' -f 1 | tr -d v`
 prev_commit_hash=`echo $tag_commit_hash | cut -d'-' -f 3 | cut -c 2-`
 


### PR DESCRIPTION
I fixed the pre-commit hook to take also lightweight tags into account. The updated githook can be installed locally with the following one-liner:
```
find .git/hooks -type l -exec rm {} \; && find .githooks -type f -exec ln -sf ../../{} .git/hooks/ \;
```
This will symlink the pre-commit hook under /.githooks into /.git/hooks/
