### PR TITLE
Set navigation order in doc pages via the pre-commit hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -44,19 +44,23 @@ do
   then
     sedcmd=$(echo $navorderline's#.*#nav_order: '$nav_order'#')
     sed -i "$sedcmd" $opfile
+	
   else
     yamlsep=$(cat -n $opfile | grep -e '---' | awk '{print $1}')
     firstsep=$(echo $yamlsep | awk '{print $1}')
     sepnb=$(echo $yamlsep | wc -w)
+	
     if [ $sepnb -ge 2 ] && [ $firstsep -eq 1 ]
     then
       secondsep=$(echo $yamlsep | awk '{print $2}')
       awkcmd=$(echo "NR==${secondsep}{print \"nav_order: ${nav_order}\"}1")
-      awk "$awkcmd" $opfile
+	  
     else
       awkcmd=$(echo "NR==1{print RS \"---\" RS \"nav_order: ${nav_order}\" RS \"---\" RS}1")
-      awk "$awkcmd" $opfile > "$opfile.tmp"
-      mv "$opfile.tmp" $opfile
-     fi
+    fi
+	
+    awk "$awkcmd" $opfile > "$opfile.tmp"
+	mv "$opfile.tmp" $opfile
+	
   fi
 done

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -64,3 +64,5 @@ do
 	
   fi
 done
+
+git add "${sourcedir}/*.md"

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# Write MASH-FRET release version and last commit hash in file 
+# MASH-FRET/.release_version.json, which is used by MASH-FRET's GUI.
+# Author: Fabio Steffen
 tag_commit_hash=`git describe --always --tags`
 tag=`echo $tag_commit_hash | cut -d'-' -f 1 | tr -d v`
 prev_commit_hash=`echo $tag_commit_hash | cut -d'-' -f 3 | cut -c 2-`
@@ -10,3 +13,50 @@ echo \"prev_commit_hash\" : \"$prev_commit_hash\" >> MASH-FRET/.release_version.
 echo } >> MASH-FRET/.release_version.json
 
 git add MASH-FRET/.release_version.json
+
+
+# Set YAML property "nav_order" in pages of doc section "Output files" usign the 
+# alphabetical order of .md file names. Strangely, this is not done automatically 
+# when "nav_order" is absent. Therefore, "nav_order" must be updated manually for 
+# every single file.
+# Author: Mélodie Hadzic
+sourcedir='docs/output-files'
+parentfile="${sourcedir}/output-files.md"
+file_list=$(ls $sourcedir/*.md | sort)
+nav_order=0
+for opfile in $file_list
+do
+  # ignore parent file
+  if [ "$opfile" = "$parentfile" ]
+  then
+    continue
+  fi
+  
+  # update navigation order
+  (( nav_order++ ))
+  
+  # search for YAML property "nav_order" in file
+  navorderline=$(cat -n $opfile | grep nav_order | awk '{print $1}')
+  isnavorder=$(echo $navorderline | wc -m)
+  
+  # replace "nav_order" if exists, insert a new line otherwise
+  if [ $isnavorder -gt 1 ]
+  then
+    sedcmd=$(echo $navorderline's#.*#nav_order: '$nav_order'#')
+    sed -i "$sedcmd" $opfile
+  else
+    yamlsep=$(cat -n $opfile | grep -e '---' | awk '{print $1}')
+    firstsep=$(echo $yamlsep | awk '{print $1}')
+    sepnb=$(echo $yamlsep | wc -w)
+    if [ $sepnb -ge 2 ] && [ $firstsep -eq 1 ]
+    then
+      secondsep=$(echo $yamlsep | awk '{print $2}')
+      awkcmd=$(echo "NR==${secondsep}{print \"nav_order: ${nav_order}\"}1")
+      awk "$awkcmd" $opfile
+    else
+      awkcmd=$(echo "NR==1{print RS \"---\" RS \"nav_order: ${nav_order}\" RS \"---\" RS}1")
+      awk "$awkcmd" $opfile > "$opfile.tmp"
+      mv "$opfile.tmp" $opfile
+     fi
+  fi
+done

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -15,10 +15,12 @@ echo } >> MASH-FRET/.release_version.json
 git add MASH-FRET/.release_version.json
 
 
-# Set YAML property "nav_order" in pages of doc section "Output files" usign the 
+# Set YAML property "nav_order" in pages of doc section "Output files" using the 
 # alphabetical order of .md file names. Strangely, this is not done automatically 
 # when "nav_order" is absent. Therefore, "nav_order" must be updated manually for 
 # every single file.
+# To do: (1) restrict execution to commits that concern docs/output-files
+#        (2) use alphabetical order of page titles
 # Author: Mélodie Hadzic
 sourcedir='docs/output-files'
 parentfile="${sourcedir}/output-files.md"

--- a/MASH-FRET/.release_version.json
+++ b/MASH-FRET/.release_version.json
@@ -1,4 +1,4 @@
 {
 "tag" : "1.3.1",
-"prev_commit_hash" : "48221723"
+"prev_commit_hash" : "1.3.1"
 }

--- a/MASH-FRET/.release_version.json
+++ b/MASH-FRET/.release_version.json
@@ -1,4 +1,4 @@
 {
 "tag" : "1.3.1",
-"prev_commit_hash" : "1.3.1"
+"prev_commit_hash" : "04f14254"
 }

--- a/MASH-FRET/.release_version.json
+++ b/MASH-FRET/.release_version.json
@@ -1,4 +1,4 @@
 {
 "tag" : "1.3.1",
-"prev_commit_hash" : "04f14254"
+"prev_commit_hash" : "7a24233c"
 }

--- a/MASH-FRET/.release_version.json
+++ b/MASH-FRET/.release_version.json
@@ -1,4 +1,4 @@
 {
 "tag" : "1.3.1",
-"prev_commit_hash" : "7a24233c"
+"prev_commit_hash" : "8537b5ed"
 }

--- a/docs/output-files/pdf-transition-analysis-bootstrap-plots.md
+++ b/docs/output-files/pdf-transition-analysis-bootstrap-plots.md
@@ -2,7 +2,7 @@
 layout: default
 title: (*.pdf) Transition analysis bootstrap plots
 parent: /output-files.html
-nav_order: 22
+nav_order: 23
 nav_exclude: 1
 ---
 

--- a/docs/output-files/sira-mash-video.md
+++ b/docs/output-files/sira-mash-video.md
@@ -2,7 +2,7 @@
 layout: default
 title: (*.sira) MASH video
 parent: /output-files.html
-nav_order: 23
+nav_order: 24
 nav_exclude: 1
 ---
 

--- a/docs/output-files/spots-spots-coordinates.md
+++ b/docs/output-files/spots-spots-coordinates.md
@@ -2,7 +2,7 @@
 layout: default
 title: (*.spots) Spotfinder coordinates
 parent: /output-files.html
-nav_order: 24
+nav_order: 25
 nav_exclude: 1
 ---
 

--- a/docs/output-files/tbl-intensity-statistics.md
+++ b/docs/output-files/tbl-intensity-statistics.md
@@ -2,7 +2,7 @@
 layout: default
 title: (*.tbl) Intensity statistics
 parent: /output-files.html
-nav_order: 25
+nav_order: 26
 nav_exclude: 1
 ---
 

--- a/docs/output-files/tdp-transition-density-plot.md
+++ b/docs/output-files/tdp-transition-density-plot.md
@@ -2,7 +2,7 @@
 layout: default
 title: (*.tdp) Transition density plot
 parent: /output-files.html
-nav_order: 26
+nav_order: 27
 nav_exclude: 1
 ---
 

--- a/docs/output-files/traces-smart-traces.md
+++ b/docs/output-files/traces-smart-traces.md
@@ -2,7 +2,7 @@
 layout: default
 title: (*.traces) SMART traces
 parent: /output-files.html
-nav_order: 27
+nav_order: 28
 nav_exclude: 1
 ---
 

--- a/docs/output-files/txt-histogram-state-configurations.md
+++ b/docs/output-files/txt-histogram-state-configurations.md
@@ -2,7 +2,7 @@
 layout: default
 title: (*.txt) State configurations from Histogram analysis
 parent: /output-files.html
-nav_order: 33
+nav_order: 29
 nav_exclude: 1
 ---
 

--- a/docs/output-files/txt-histogram-state-populations.md
+++ b/docs/output-files/txt-histogram-state-populations.md
@@ -2,7 +2,7 @@
 layout: default
 title: (*.txt) State populations from Histogram analysis
 parent: /output-files.html
-nav_order: 34
+nav_order: 30
 nav_exclude: 1
 ---
 

--- a/docs/output-files/txt-traces-from-simulation.md
+++ b/docs/output-files/txt-traces-from-simulation.md
@@ -2,7 +2,7 @@
 layout: default
 title: (*.txt) Traces from simulation
 parent: /output-files.html
-nav_order: 28
+nav_order: 32
 nav_exclude: 1
 ---
 

--- a/docs/output-files/txt-traces-from-video.md
+++ b/docs/output-files/txt-traces-from-video.md
@@ -2,7 +2,7 @@
 layout: default
 title: (*.txt) Traces from video processing
 parent: /output-files.html
-nav_order: 29
+nav_order: 33
 nav_exclude: 1
 ---
 

--- a/docs/output-files/txt-traces-qub.md
+++ b/docs/output-files/txt-traces-qub.md
@@ -2,7 +2,7 @@
 layout: default
 title: (*.txt) QUB traces
 parent: /output-files.html
-nav_order: 30
+nav_order: 34
 nav_exclude: 1
 ---
 

--- a/docs/output-files/txt-transition-density-coordinates.md
+++ b/docs/output-files/txt-transition-density-coordinates.md
@@ -2,7 +2,7 @@
 layout: default
 title: (*.txt) Transition density coordinates
 parent: /output-files.html
-nav_order: 36
+nav_order: 35
 nav_exclude: 1
 ---
 


### PR DESCRIPTION
Strangely, just-the-docs do not sort pages alphabetically according to the page titles (as opposed to what is said [here](https://pmarsceill.github.io/just-the-docs/docs/navigation-structure/#ordering-pages)).
Therefore, when adding new files to the doc section "Output files", the navigation order must be updated manually for every single file by setting the property `nav_order` in the YAML headers. 

Here, I've added a second step to the pre-commit hook that set the `nav_order` property of all files in the `docs/output-files` directory, according to the alphabetical order of page's file names. 
The hook executes prior each commit and add the modified files to the index prior validating the commit.

For the modifications to take effect, the `.git/hooks/pre-commit` file must be synchronized with the `.githooks/pre-commit` file. To do so, you can use the instructions given here: https://github.com/RNA-FRETools/MASH-FRET/pull/69#issue-519248001

To do for improvement: 
- [ ] restrict the execution to commits that concern `docs/output-files/*` (would reduce commit time and logs)
- [ ] use alphabetical order of page titles instead of page file names
