### PR TITLE
Add "readme" for mex compilation issue on Linux

### DIFF
--- a/MASH-FRET/source/divers/mex-compilation/checkMASHmex.m
+++ b/MASH-FRET/source/divers/mex-compilation/checkMASHmex.m
@@ -1,0 +1,126 @@
+function checkMASHmex()
+
+% compile molecule localization method Schmied2012
+if exist('forloop','file')~=3
+    cd(fileparts(which('forloop.c')));
+    try
+        mex('forloop.c');
+    catch err
+        dispMatlabErr(err);
+    end
+end
+
+% compile image filters
+% if exist('FilterArray','file')~=3
+%     pname = fileparts(which('FilterArray.c'));
+%     % set runtime library path for LINUX
+%     if strcmp(computer,'GLNXA86') || strcmp(computer,'GLNXA64')
+%         system(['LD_LIBRARY_PATH=$LD_LIBRARY_PATH:',matlabroot,filesep,...
+%             'glnxa64:',matlabroot,filesep,'sys',filesep,'os',filesep,...
+%             'glnxa64']);
+%     end
+%     if strcmp(computer,'PCWIN') || strcmp(computer,'GLNX86') % 32bit OS
+%         runtimefolder = 'runtime32';
+%         libflag = '-lITASL32';
+% 
+%     elseif strcmp(computer,'PCWIN64') || strcmp(computer,'GLNX64') % 64bit OS
+%         runtimefolder = 'runtime64';
+%         libflag = '-lITASL64';
+%     end
+%     cd([pname,filesep,'..',filesep,runtimefolder]);
+%     try
+%         mex('-R2018a',[pname,filesep,'FilterArray.c'],...
+%             ['-L',pname,filesep,'lib'],libflag);
+%     catch err
+%         dispMatlabErr(err);
+%     end
+% end
+
+% compile SIF file import
+if exist('SIFImport','file')~=3
+    
+    % libraries unavailable for LINUX
+    if strcmp(computer,'GLNXA86') || strcmp(computer,'GLNXA64') || ...
+            strcmp(computer,'MACI86') || strcmp(computer,'MACI64')
+        disp(['import of old versions of SIF files is not supported ',...
+            'on MacOS and Linux systems']);
+    else
+        pname = fileparts(which('SIFImport.c'));
+
+        if strcmp(computer,'PCWIN') || strcmp(computer,'MACI86') % 32bit OS
+            runtimefolder = 'runtime32';
+            libflag = '-lITASL32';
+
+        elseif strcmp(computer,'PCWIN64') || strcmp(computer,'MACI64') % 64bit OS
+            runtimefolder = 'runtime64';
+            libflag = '-lITASL64';
+        end
+        cd([pname,filesep,'..',filesep,runtimefolder]);
+        try
+            mex('-R2018a',[pname,filesep,'SIFImport.c'],...
+                ['-L',pname,filesep,'lib'],libflag);
+        catch err
+            dispMatlabErr(err);
+        end
+    end
+end
+
+% compile SPE file import
+if exist('SPEImport','file')~=3
+    
+    % libraries unavailable for LINUX
+    if strcmp(computer,'GLNXA86') || strcmp(computer,'GLNXA64') || ...
+            strcmp(computer,'MACI86') || strcmp(computer,'MACI64')
+        disp(['import of SPE files is not supported on MacOS and Linux ',...
+            'systems']);
+    else
+        pname = fileparts(which('SPEImport.c'));
+
+        if strcmp(computer,'PCWIN') % 32bit OS
+            runtimefolder = 'runtime32';
+            libflag = '-lITASL32';
+
+        elseif strcmp(computer,'PCWIN64') % 64bit OS
+            runtimefolder = 'runtime64';
+            libflag = '-lITASL64';
+        end
+        cd([pname,filesep,'..',filesep,runtimefolder]);
+        try
+            mex('-R2018a',[pname,filesep,'SPEImport.c'],...
+                ['-L',pname,filesep,'lib'],libflag);
+        catch err
+            dispMatlabErr(err);
+        end
+    end
+end
+
+% compile DPH training algorithm
+if exist('trainPH','file')~=3
+    cd(fileparts(which('trainPH.c')));
+    try
+        mex -R2018a -O trainPH.c vectop.c
+    catch err
+        dispMatlabErr(err);
+    end
+end
+
+% compile Baum-Welch algorithm
+if exist('baumwelch','file')~=3
+    cd(fileparts(which('baumwelch.c')));
+    try
+        mex -R2018a -O baumwelch.c vectop.c fwdbwd.c
+    catch err
+        dispMatlabErr(err);
+    end
+end
+
+% compile model error calculation
+if exist('calcmdlconfiv','file')~=3
+    cd(fileparts(which('calcmdlconfiv.c')));
+    try
+        mex -R2018a -O calcmdlconfiv.c vectop.c fwdbwd.c
+    catch err
+        dispMatlabErr(err);
+    end
+end
+    

--- a/MASH-FRET/source/divers/mex-compilation/readme.txt
+++ b/MASH-FRET/source/divers/mex-compilation/readme.txt
@@ -1,0 +1,26 @@
+To solve MEX file compilation issues happening at MASH-FRET startup on Linux, please read the following instructions.
+
+ERROR MESSAGE 1:
+	An error occurred:
+	Supported compiler not found. For options, visit https://www.mathworks.com/support/compilers.
+	function: checkMASHmex, line: 7
+	function: MASH, line: 13
+
+SOLUTION 1:
+	MATLAB supports GCC compiler up to version 9.x
+	Install gcc-9 package with the shell command:
+		sudo apt install gcc-9
+	Create a soft link "gcc" pointing to gcc-9 with the shell comand:
+		sudo ln -s /usr/bin/gcc-9 /usr/bin/gcc
+
+ERROR MESSAGE 2:
+	An error occurred:
+	/usr/bin/ld : ne peut trouver -lstdc++
+	collect2: error: ld returned 1 exit status
+	function: checkMASHmex, line: 7
+	function: MASH, line: 13
+	
+SOLUTION 2:
+	MATLAB looks for a file named libstdc++.so which is named "libstdc++.so.6" on your computer
+	Create a soft link "libstdc++.so" pointing to libstdc++.so.6 with the shell comand:
+		sudo ln -s /usr/lib/x86_64-linux-gnu/libstdc++.so.6 /usr/lib/x86_64-linux-gnu/libstdc++.so


### PR DESCRIPTION
The readme file gives instructions for Linux users on how to solve mex-compiler-related errors at MASH-FRET startup.
Errors are due to the absence of the gcc compiler or to an unsupported version of the gcc compiler (according to [MATLAB answer #99897](https://fr.mathworks.com/matlabcentral/answers/99897-how-can-i-determine-the-platform-and-compiler-version-that-i-am-using#accepted_answer_109245)).
Additional errors can come from MATLAB calling `gcc` and `libstdc++.so` that are respectively named `gcc-9` and `libstdc++.so.6` on the Linux machine. This is solve by creating the appropriate symbolic links.