### PR TITLE
Manage merging of projects with different video sampling times

### DIFF
--- a/MASH-FRET/.release_version.json
+++ b/MASH-FRET/.release_version.json
@@ -1,4 +1,4 @@
 {
 "tag" : "1.3.3.1",
-"prev_commit_hash" : "1.3.3.1"
+"prev_commit_hash" : "95082dc3"
 }


### PR DESCRIPTION
This modification fixes #90.

To allow the merging of projects that differ in their video sampling times, a message box is popping up where the user can input manually the sampling time for the merged project:

![image](https://github.com/RNA-FRETools/MASH-FRET/assets/7199132/bd839374-22e7-4e22-a85f-3bd69a69751a)

If the user leaves the input empty or closes the box, the merging process will be aborted.