### PR TITLE
Correct exclusion of molecule coordinates and other minor stuff

### DIFF
--- a/MASH-FRET/.release_version.json
+++ b/MASH-FRET/.release_version.json
@@ -1,4 +1,4 @@
 {
 "tag" : "1.3.3.1",
-"prev_commit_hash" : "b17d99f9"
+"prev_commit_hash" : "8d24803a"
 }

--- a/MASH-FRET/.release_version.json
+++ b/MASH-FRET/.release_version.json
@@ -1,4 +1,4 @@
 {
 "tag" : "1.3.3.1",
-"prev_commit_hash" : "82fff562"
+"prev_commit_hash" : "dfcc9143"
 }

--- a/MASH-FRET/.release_version.json
+++ b/MASH-FRET/.release_version.json
@@ -1,4 +1,4 @@
 {
 "tag" : "1.3.3.1",
-"prev_commit_hash" : "8d24803a"
+"prev_commit_hash" : "82fff562"
 }

--- a/MASH-FRET/source/mod-trace-processing/dwell-time analysis/ud_DTA.m
+++ b/MASH-FRET/source/mod-trace-processing/dwell-time analysis/ud_DTA.m
@@ -28,6 +28,9 @@ p_panel = curr{4};
 chan = fix{3}(4);
 method = p_panel{1}(1);
 toBot = p_panel{1}(2);
+recalc = p_panel{1}(3);
+
+set(h.checkbox_recalcStates,'value',recalc);
 
 data_str = getStrPop('DTA_chan',{labels FRET S exc clr});
 nFRET = size(FRET,1);
@@ -162,6 +165,10 @@ else
             set(h_param([2,3]),'Enable','off','string','');
             set(h_param_txt([2,3]),'Enable','off');
             set(h_param(1),'TooltipString','Maximum number of states');
+
+        case 7 % imported
+            set(h_param(1:3),'Enable','off','string','');
+            set(h_param_txt(1:3),'Enable','off');
     end
 end
 

--- a/MASH-FRET/source/mod-transition-analysis/_callbacks/popupmenu_TDPtag_Callback.m
+++ b/MASH-FRET/source/mod-transition-analysis/_callbacks/popupmenu_TDPtag_Callback.m
@@ -27,5 +27,5 @@ p.TDP.curr_tag(proj) = val;
 h.param = p;
 guidata(h_fig, h);
 
-% update TDP and plot
-pushbutton_TDPupdatePlot_Callback(obj, evd, h_fig);
+% update plots and GUI
+updateFields(h_fig, 'TDP');

--- a/MASH-FRET/source/mod-video-processing/_callbacks/pushbutton_trGo_Callback.m
+++ b/MASH-FRET/source/mod-video-processing/_callbacks/pushbutton_trGo_Callback.m
@@ -9,6 +9,7 @@ p = h.param;
 viddim = p.proj{p.curr_proj}.movie_dim;
 nChan = p.proj{p.curr_proj}.nb_channel;
 curr = p.proj{p.curr_proj}.VP.curr;
+prm = p.proj{p.curr_proj}.VP.prm;
 def = p.proj{p.curr_proj}.VP.def;
 coord2tr = curr.res_crd{1};
 tr = curr.res_crd{2};
@@ -46,8 +47,8 @@ for mov = 1:nMov
     q.res_y(mov) = viddim{mov}(2);
 end
 q.nChan = nChan;
-q.spotDmin = ones(1,nChan);
-q.edgeDmin = ones(1,nChan);
+q.spotDmin = prm.gen_crd{2}{3}(:,6)';
+q.edgeDmin = prm.gen_crd{2}{3}(:,7)';
 coordtr = applyTrafo(tr,coord2tr,q,h_fig);
 if isempty(coordtr)
     return

--- a/MASH-FRET/source/mod-video-processing/coordinates/applyTrafo.m
+++ b/MASH-FRET/source/mod-video-processing/coordinates/applyTrafo.m
@@ -58,7 +58,7 @@ if multichanvid
     lim = [0 (1:(nChan-1))*round(res_x/nChan) res_x];
 end
 
-ok = exclude_doublecoord(3, coordtr);
+ok = exclude_doublecoord(1,coordtr);
 coordtr = coordtr(ok',:);
 if ~isempty(coordtr)
     for i = 1:nChan

--- a/MASH-FRET/source/mod-video-processing/coordinates/exclude_doublecoord.m
+++ b/MASH-FRET/source/mod-video-processing/coordinates/exclude_doublecoord.m
@@ -1,6 +1,6 @@
 function ok = exclude_doublecoord(tol, coord)
-% Return a boolean vector regarding weather the input coordinates are in
-% double
+% Return a boolean vector regarding weather the input coordinates are
+% doublons
 % "coord" >> [n-by-2*m] array, contains the (x,y) coordinates in the m
 % channels
 % "tol" >> minimum spot-spot distance


### PR DESCRIPTION
In VP, molecule coordinates were cleaned after spot finding but not after transformation which yield neighbouring molecules with overlapping signals in the final set.
In this branch, the exclusion criteria of the minimum inter-spot and image edge-spot distances are applied on the transformed coordinates set.

in TP, the update of the value of the UI checkbox `Adjust to data` was omitted, which was very confusing.
In this branch, the value is properly set each time the GUI update function in called.

in TA, the targetted plot was reset to `TDP` every time the popup `molecule subgroup` was used, which made it very difficult to compare the same plot for different subgroups.
In this branch, the targetted plot remains the same after the subgroup selection changes.