### PR TITLE
updates ML-DPH and BW analysis as in DPH article in prep.

### DIFF
--- a/MASH-FRET/.release_version.json
+++ b/MASH-FRET/.release_version.json
@@ -1,4 +1,4 @@
 {
 "tag" : "1.3.3.1",
-"prev_commit_hash" : "b17d99f9"
+"prev_commit_hash" : "8d24803a"
 }

--- a/MASH-FRET/source/mod-transition-analysis/_callbacks/pushbutton_TA_refreshModel_Callback.m
+++ b/MASH-FRET/source/mod-transition-analysis/_callbacks/pushbutton_TA_refreshModel_Callback.m
@@ -217,7 +217,16 @@ expPrm.dt = dat(:,[1,4,end-1,end]);
 expPrm.excl = excl;
 expPrm.seq = seq;
 
-[tp,err,ip,simdat] = optimizeProbMat(states,expPrm,tp0,T_bw); % transition prob
+% eps = minpercent*nMol/sum(expPrm.Ls);
+eps = 1/(sum(expPrm.Ls)-2*numel(expPrm.Ls));
+schm = true(J);
+tp = ones(J);
+iter = 1;
+while iter==1 || any(tp(schm)<eps)
+    schm = schm & tp>=eps;
+    [tp,err,ip,simdat] = optimizeProbMat(states,expPrm,tp0,T_bw,schm); % transition prob
+    iter = iter+1;
+end
 
 prm.mdl_res(1:4) = {tp,err,ip,simdat};
 

--- a/MASH-FRET/source/mod-transition-analysis/c-code/trainPH.c
+++ b/MASH-FRET/source/mod-transition-analysis/c-code/trainPH.c
@@ -4,7 +4,7 @@
  * Dwell time counts must be strictly positive
  *
  * Corresponding MATLAB executing command:
- * [a,T,logL] = trainPH(a0,T0,cnts);
+ * [a,T,logL] = trainPH(a0,T0,t0,cnts);
  *
  * MEX-compilation command:
  * mex  -R2018a -O trainPH.c vectop.c
@@ -21,7 +21,8 @@
 #include "vectop.h"
 #include "trainPH.h"
 
-void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
+void mexFunction(int nlhs, mxArray *plhs[], int nrhs, 
+        const mxArray *prhs[])
 {
 	// check input and output arguments
 	if (!validArg(nlhs, plhs, nrhs, prhs)){
@@ -30,25 +31,32 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
 	
 	// get input dimensions
 	int J = (int) mxGetN(prhs[1]);
-	int nDt = (int) mxGetN(prhs[2]);
+	int nDt = (int) mxGetN(prhs[3]);
+    int nb_int = 0;
 	
 	// get input values
 	const double *a0 = (const double *) mxGetDoubles(prhs[0]); // starting initial state prob.
 	const double *T0 = (const double *) mxGetDoubles(prhs[1]); // starting transition matrix
-	const double *cnts = (const double *) mxGetDoubles(prhs[2]); // dwell times and counts
+	const double *t0 = (const double *) mxGetDoubles(prhs[2]); // starting exit prob
+	const double *cnts = (const double *) mxGetDoubles(prhs[3]); // dwell times and counts
 	
 	// prepare output
 	plhs[0] = mxCreateDoubleMatrix(1,J,mxREAL); // PH initial state prob.
 	plhs[1] = mxCreateDoubleMatrix(J,J,mxREAL); // PH transition matrix
 	plhs[2] = mxCreateDoubleScalar(0); // Likelihood of PH given the dwell times
+    plhs[3] = mxCreateDoubleScalar(0); // Number of printed characters
 	double *a = mxGetDoubles(plhs[0]);
 	double *T = mxGetDoubles(plhs[1]);
 	double *logL = mxGetDoubles(plhs[2]);
+    double *nb = mxGetDoubles(plhs[3]);
+    double t[J];
 
 	// train PH
 	setVect(T,T0,J*J);
 	setVect(a,a0,J);
-	bool cvg = optDPH(T,a,logL,cnts,J,nDt);
+	setVect(t,t0,J);
+	bool cvg = optDPH(T,t,a,logL,cnts,J,nDt,&nb_int);
+    *nb = (double) nb_int;
 	
 	// return empty arrays if EM did not converge
 	if (!cvg){
@@ -62,12 +70,13 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
 }
 
 
-bool optDPH(double* T, double* a, double* logL, const double* cnts, int J, int nDt){
+bool optDPH(double* T, double* t, double* a, double* logL, const 
+        double* cnts, int J, int nDt, int* nb){
 	
-	int i = 0, j = 0, nb = 0;
+	int i = 0, j = 0;
 	bool cvg = 0;
 	double m = 0, dmax = 0, logL_prev = 0, totCnt = 0;
-	double t[J], T_prev[J*J], a_prev[J], B[J], Ni[J], Nij[J*J];
+	double T_prev[J*J], a_prev[J], B[J], Ni[J], Nij[J*J];
 
 	// build vectorized matrix indexes outside the while loop for speed
 	int** id_T = (int **)malloc(J * sizeof(int *));
@@ -94,53 +103,75 @@ bool optDPH(double* T, double* a, double* logL, const double* cnts, int J, int n
 	buildIdMat(id_mat,2*J,2*J);
 	buildIdMat(id_Jv,J,1);
 	buildIdMat(id_Jh,1,J);
+    
+//     // calculate initial likelihood (discrete PH)
+//     *logL = 0;
 	
-	// calculate starting exit prob.
-	for (i=0; i<J; i++){
-		t[i] = 1;
-		for (j=0; j<J; j++){
-			t[i] = t[i] - T[id_T[i][j]];
-		}
-	}
-	
-	// calculate initial likelihood
-	*logL = calcDPHlogL( (const double*) T, (const double*) a, (const double*) t, cnts,J,nDt, (const int**) id_T, (const int**) id_P, (const int**) id_Jv);
-	nb = dispDPHres(m,*logL-logL_prev,dmax, (const double*) T, (const double*) a,J, (const int**) id_T,0);
-	
-	// calculate total number of dwell times
-	for (i=0; i<nDt; i++){
-		totCnt = totCnt + cnts[id_P[1][i]];
-	}
-	
+	// calculate initial likelihood (continuous PH)
+	*logL = calcDPHlogL( (const double*) T, (const double*) a, 
+            (const double*) t, cnts,J,nDt, (const int**) id_T, 
+            (const int**) id_P, (const int**) id_Jv);
+    if (!mxIsFinite(*logL)){ cvg = true; }
+    
+    // show initial fit
+	*nb = dispDPHres(m,*logL-logL_prev,dmax, (const double*) T, 
+            (const double*) a,J, (const int**) id_T,0);
+
+    // E-M iterations
 	while(!cvg && m<MAXITER){
 		
 		m = m+1;
 		
+        // store previous inferrence
 		setVect(T_prev,(const double*) T,J*J);
 		setVect(a_prev,(const double*) a,J);
 		logL_prev = *logL;
 		
 		// E-step
-		EstepDPH(B,Nij,Ni,cnts,(const double*) a,(const double*) T,(const double*) t,nDt,J, 
-				(const int**) id_T,(const int**) id_P,(const int**) id_Jh,(const int**) id_Jv,(const int**) id_mat);
-				
+		EstepDPH(B,Nij,Ni,cnts,(const double*) a,(const double*) T,
+                (const double*) t,nDt,J,(const int**) id_T,
+                (const int**) id_P,(const int**) id_Jh,(const int**) id_Jv,
+                (const int**) id_mat, &totCnt);
+        
+//         //calculates likelihood (discrete PH)
+//         *logL = calcDPHlogL_2((const double*) T, (const double*) a, 
+//                 (const double*) t, (const double*) B, (const double*) Nij, 
+//                 (const double*) Ni,J, (const int**) id_T);
+//         if (!mxIsFinite(*logL)){ break; }
+        		
 		// M-step
-		MstepDPH(a,T,t,(const double*) B,(const double*) Nij,(const double*) Ni,totCnt,J,(const int**) id_T);
+		MstepDPH(a,T,t,(const double*) B,(const double*) Nij,
+                (const double*) Ni,totCnt,J,(const int**) id_T);
 		
-		// likelihood
-		*logL = calcDPHlogL( (const double*) T, (const double*) a, (const double*) t, cnts,J,nDt, (const int**) id_T, (const int**) id_P, (const int**) id_Jv);
+		// calculates likelihood (continuous PH)
+		*logL = calcDPHlogL((const double*) T,(const double*) a,
+                (const double*) t,cnts,J,nDt,(const int**) id_T,
+                (const int**) id_P,(const int**) id_Jv);
+        if (!mxIsFinite(*logL)){ break; }
 
 		// check for convergence
-		dmax = calcMaxDev( (const double*) T, (const double*) T_prev, (const double*) a, (const double*) a_prev,J);
-		//if (dmax<DMIN){ cvg = 1; }
-		if ((*logL-logL_prev)<DLMIN){ cvg = 1; }
+		dmax = calcMaxDev((const double*) T,(const double*) T_prev,
+                (const double*) a,(const double*) a_prev,J);
+		if (m>1 && ((*logL-logL_prev)<DLMIN || dmax<DMIN)){ cvg = 1; }
 		
-		nb = dispDPHres(m,*logL-logL_prev,dmax, (const double*) T, (const double*) a,J, (const int**) id_T,nb);
+        // show progress
+		*nb = dispDPHres(m,*logL-logL_prev,dmax,(const double*) T,
+                (const double*) a,J,(const int**) id_T,*nb);
 	}
 	
+    // manage failure
 	if (!cvg){
-		nb = eraseAndWrite("maximum number of iterations has been reached\n",nb);
+        if (m>=MAXITER){
+            *nb = eraseAndWrite(
+                    "maximum number of iterations has been reached\n",*nb);
+        }
+        else { 
+            *nb = eraseAndWrite("infinite log-likelihood\n",*nb); 
+        }
 	}
+    else if (m==0){
+        *nb = eraseAndWrite("ill-defined starting guess\n",*nb); 
+    }
 	
 	// free memory outside the while loop for speed
 	for (i=0; i<J; i++){ free(id_T[i]); }
@@ -158,13 +189,16 @@ bool optDPH(double* T, double* a, double* logL, const double* cnts, int J, int n
 }
 
 
-void EstepDPH(double* B, double* Nij, double* Ni, const double* P, const double* a, const double* T, const double* t, int nDt, int J, 
-		const int** id_T, const int** id_P, const int** id_Jh, const int** id_Jv, const int** id_mat){
+void EstepDPH(double* B, double* Nij, double* Ni, const double* P, 
+        const double* a, const double* T, const double* t, int nDt, int J, 
+		const int** id_T, const int** id_P, const int** id_Jh, 
+        const int** id_Jv, const int** id_mat, double* totCount){
 	
 	int i = 0, j = 0, n = 0;
-	double ta[J*J], tmp_J[J], Tpow_n[J*J], K_n[J*J], mat[4*J*J], matpow_n[4*J*J], dt, cnt, denom_n, sum_j;
+	double ta[J*J], Tt[J], Tpow_n[J*J], K_n[J*J], mat[4*J*J], 
+            matpow_n[4*J*J], dt, cnt, denom_n, sum_j;
 	
-	// initialize expectations and calculate exit probabilities
+	// initialize expectations
 	for (i=0; i<J; i++){
 		B[i] = 0;
 		Ni[i] = 0;
@@ -173,57 +207,66 @@ void EstepDPH(double* B, double* Nij, double* Ni, const double* P, const double*
 		}
 	}
 	
-	// initialize mat
+	// vector product {t}*{a}
 	matprod(ta,t,a,J,1,J,id_T,id_Jv,id_Jh);
+    
+    // builds matrix {T ta; 0 T}
 	for (i=0; i<2*J; i++){
 		for (j=0; j<2*J; j++){
 			if (i<J && j<J){ mat[id_mat[i][j]] = T[id_T[i][j]]; }
-			else if (i>=J && j>=J){ mat[id_mat[i][j]] = T[id_T[i-J][j-J]]; }
+			else if (i>=J && j>=J){ 
+                mat[id_mat[i][j]] = T[id_T[i-J][j-J]]; 
+            }
 			else if (i>=J && j<J){ mat[id_mat[i][j]] = 0; }
 			else if (i<J && j>=J){ mat[id_mat[i][j]] = ta[id_T[i][j-J]]; }
 		}
 	}
 	
 	// expectation calculations
+    *totCount = 0;
 	for (n=0; n<nDt; n++){
 		
 		dt = P[id_P[0][n]];
 		cnt = P[id_P[1][n]];
 		denom_n = 0;
 		
-		// {T^(x-1)} and {K(x)} matrices
+		// matrix {T ta; 0 T}^(x-1)
 		matpow(matpow_n,(const double*) mat,2*J,dt-1,id_mat);
+        
+        // isolates matrices {T^(x-1)} and {K(x)}
 		for (i=0; i<J; i++){
 			for (j=0; j<J; j++){
 				Tpow_n[id_T[i][j]] = matpow_n[id_mat[i][j]];
 				K_n[id_T[i][j]] = matpow_n[id_mat[i][j+J]];
 			}
 		}
+        
+        // matrix product {T^(x-1)}*{t}
+		matprod(Tt,Tpow_n,t,J,J,1,id_Jv,id_T,id_Jv);
 
 		// denominator {a}*{T^(x-1)}*{t}
-		matprod(tmp_J,Tpow_n,t,J,J,1,id_Jv,id_T,id_Jv);
 		for (i=0; i<J; i++){
-			denom_n = denom_n + a[i] * tmp_J[i];
+			denom_n = denom_n + a[i] * Tt[i];
 		}
 		if (denom_n<=0 || denom_n!=denom_n){ continue; }
+        
+        // add dwell time count to total count
+        *totCount = *totCount + cnt;
 		
 		// expectations
 		for (i=0; i<J; i++){
 			sum_j = 0;
 			for (j=0; j<J; j++){
-				sum_j = sum_j + t[j] * Tpow_n[id_T[i][j]];
-			}
-			B[i] = B[i] + cnt * a[i] * sum_j / denom_n;
-			
-			sum_j = 0;
-			for (j=0; j<J; j++){
 				sum_j = sum_j + a[j] * Tpow_n[id_T[j][i]];
 			}
 			Ni[i] = Ni[i] + cnt * t[i] * sum_j / denom_n;
+
+			B[i] = B[i] + cnt * a[i] * Tt[i] / denom_n;
 			
 			if (dt>1){
 				for (j=0; j<J; j++){
-					Nij[id_T[i][j]] = Nij[id_T[i][j]] + cnt * T[id_T[i][j]] * K_n[id_T[j][i]] / denom_n;
+					Nij[id_T[i][j]] = Nij[id_T[i][j]] + 
+                            cnt * T[id_T[i][j]] * K_n[id_T[j][i]] / denom_n;
 				}
 			}
 		}
@@ -233,11 +276,21 @@ void EstepDPH(double* B, double* Nij, double* Ni, const double* P, const double*
 }
 
 
-void MstepDPH(double* a, double* T, double* t, const double* B, const double* Nij, const double* Ni, double totCnt, int J, 
+void MstepDPH(double* a, double* T, double* t, const double* B, 
+        const double* Nij, const double* Ni, double totCnt, int J, 
 		const int** id_T){
 	
 	int i = 0, j = 0;
 	double sum_i = 0;
+    
+    // initialize maximizations
+	for (i=0; i<J; i++){
+		a[i] = 0;
+		t[i] = 0;
+		for (j=0; j<J; j++){
+			T[id_T[i][j]] = 0;
+		}
+	}
 
 	for (i=0; i<J; i++){
 		// initial state probabilities
@@ -248,17 +301,20 @@ void MstepDPH(double* a, double* T, double* t, const double* B, const double* Ni
 		for (j=0; j<J; j++){
 			sum_i = sum_i + Nij[id_T[i][j]];
 		}
-		for (j=0; j<J; j++){
-			T[id_T[i][j]] = Nij[id_T[i][j]] / (Ni[i] + sum_i);
-		}
-		t[i] = Ni[i] / (Ni[i] + sum_i);
+        if ((Ni[i]+sum_i)>0){
+            for (j=0; j<J; j++){
+                T[id_T[i][j]] = Nij[id_T[i][j]] / (Ni[i] + sum_i);
+            }
+            t[i] = Ni[i] / (Ni[i] + sum_i);
+        }
 	}
 	
 	return;
 }
 
 
-double calcMaxDev(const double* T, const double* T_prev, const double* a,const double*  a_prev, int J){
+double calcMaxDev(const double* T, const double* T_prev, const double* a, 
+        const double*  a_prev, int J){
 	
 	double dmax = 0;
 	int i = 0;
@@ -276,37 +332,56 @@ double calcMaxDev(const double* T, const double* T_prev, const double* a,const d
 }
 
 
- double calcDPHlogL(const double* T, const double* a, const double* t, const double* P, int J, int nDt, 
-		const int** id_T, const int** id_P, const int** id_v){
+ double calcDPHlogL(const double* T, const double* a, const double* t, 
+         const double* P, int J, int nDt, const int** id_T, 
+         const int** id_P, const int** id_v){
 	
 	int i = 0, j = 0;
 	double logL = 0, Li = 0;
-	double Tpow[J*J], tmp[J];
+	double Tpow[J*J], Tt[J];
 
 	for (i=0; i<nDt; i++){
+        
+        // matrix {T^(x-1)} = {T}^(x-1)
 		matpow(Tpow,T,J,(P[id_P[0][i]]-1),id_T);
-		matprod(tmp,Tpow,t,J,J,1,id_v,id_T,id_v);
+        
+        // vector {Tt} = {T^(x-1)}*{t}
+		matprod(Tt,Tpow,t,J,J,1,id_v,id_T,id_v);
+        
+        // vector product {a}*{Tt}
 		Li = 0;
 		for (j=0; j<J; j++){
-			Li = Li + a[j]*tmp[j];
+			Li = Li + a[j]*Tt[j];
 		}
-		logL = logL + P[id_P[1][i]] * log(Li);
+        
+        // likelihood
+        if (Li>0){
+            logL = logL + P[id_P[1][i]] * log(Li);
+        }
 	}
 	
 	return logL;
 }
 
 
-double calcDPHlogL_2(const double* T, const double* a, const double* t, const double* B, const double* Nij, const double* Ni, 
-		int J, const int** id_T){
+double calcDPHlogL_2(const double* T, const double* a, const double* t, 
+        const double* B, const double* Nij, const double* Ni, int J, 
+        const int** id_T){
 	
 	int i = 0, j = 0;
 	double logL = 0;
 
 	for (i=0; i<J; i++){
-		logL = logL + B[i] * log(a[i]) + Ni[i] * log(t[i]);
+        if (a[i]>0){
+            logL = logL + B[i] * log(a[i]); 
+        }
+        if (t[i]>0){
+            logL = logL + Ni[i] * log(t[i]);
+        }
 		for (j=0; j<J; j++){
-			logL = logL + Nij[id_T[i][j]] * T[id_T[i][j]];
+            if (T[id_T[i][j]]>0){
+                logL = logL + Nij[id_T[i][j]] * log(T[id_T[i][j]]);
+            }
 		}
 	}
 	
@@ -328,10 +403,13 @@ int eraseAndWrite(char* str, int nb){
 	
 	// write iteration
 	nb = mexPrintf(str);
+    
+    return nb;
 }
 
 
-int dispDPHres(double m,double dL, double dmax, const double* T, const double* a, int J, const int** id_T, int nb){
+int dispDPHres(double m,double dL, double dmax, const double* T, 
+        const double* a, int J, const int** id_T, int nb){
 	char str[nb+1];
 	int i = 0, j = 0;
 	
@@ -345,24 +423,23 @@ int dispDPHres(double m,double dL, double dmax, const double* T, const double* a
 	}
 	
 	// write iteration
-	nb = mexPrintf("iteration %.0f: dL=%.3e (dLmin=%.0e) d=%.3e\n",m,dL,DLMIN,dmax);
+	nb = mexPrintf("iteration %.0f: dL=%.3e (dLmin=%.0e) d=%.3e\n",m,dL,
+            DLMIN,dmax);
 	
-	// write probabilities
-	/*
-	nb = nb + mexPrintf("Initial probabilities:\n");
-	for (i=0; i<J; i++){
-		nb = nb + mexPrintf("\t%.4f",a[i]);
-	}
-	nb = nb + mexPrintf("\n");
-	
-	nb = nb + mexPrintf("Transition probabilities:\n");
-	for (i=0; i<J; i++){
-		for (j=0; j<J; j++){
-			nb = nb + mexPrintf("\t%.4f",T[id_T[i][j]]);
-		}
-		nb = nb + mexPrintf("\n");
-	}
-	*/
+// 	// write probabilities
+// 	nb = nb + mexPrintf("Initial probabilities:\n");
+// 	for (i=0; i<J; i++){
+// 		nb = nb + mexPrintf("\t%.6f",a[i]);
+// 	}
+// 	nb = nb + mexPrintf("\n");
+// 	
+// 	nb = nb + mexPrintf("Transition probabilities:\n");
+// 	for (i=0; i<J; i++){
+// 		for (j=0; j<J; j++){
+// 			nb = nb + mexPrintf("\t%.6f",T[id_T[i][j]]);
+// 		}
+// 		nb = nb + mexPrintf("\n");
+// 	}
 	mexEvalString("drawnow;");
 	
 	return nb;
@@ -375,11 +452,11 @@ bool validArg(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]){
 	char str[100];
 	
 	/* Check for proper number of input and output arguments. */    
-	if (nrhs!=3) {
-		mexErrMsgTxt("Three input arguments are required.");
+	if (nrhs!=4) {
+		mexErrMsgTxt("Four input arguments are required.");
 		return 0;
 	} 
-	if (nlhs>3) {
+	if (nlhs>4) {
 		mexErrMsgTxt("Too many output arguments.");
 		return 0;
 	}
@@ -399,10 +476,14 @@ bool validArg(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]){
 	if (J<=0){
 		mexErrMsgTxt("Input (1) must contain at least one element.");
 		return 0;
+	}int K = (int) mxGetNumberOfElements(prhs[2]);
+	if (K!=J){
+		mexErrMsgTxt("Input (1) and (3) must contain the same number of elements.");
+		return 0;
 	}
 	int J1 = (int) mxGetM(prhs[1]);
 	if (J1!=J){
-		mexErrMsgTxt("The numbers of elements in input (1) and of rows in input (2) must be equal.");
+		mexErrMsgTxt("The numbers of elements in inputs (1) and (3) must be equal to the number of rows in input (2).");
 		return 0;
 	}
 	int J2 = (int) mxGetN(prhs[1]);
@@ -411,14 +492,14 @@ bool validArg(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]){
 		return 0;
 	}
 	
-	int nRows = (int) mxGetM(prhs[2]);
-	int nDt = (int) mxGetN(prhs[2]);
+	int nRows = (int) mxGetM(prhs[3]);
+	int nDt = (int) mxGetN(prhs[3]);
 	if (nRows!=2){
-		mexErrMsgTxt("Input(3) must have 2 rows.");
+		mexErrMsgTxt("Input(4) must have 2 rows.");
 		return 0;
 	}
 	if (nDt<1){
-		mexErrMsgTxt("Input(3) must have at least 1 column.");
+		mexErrMsgTxt("Input(4) must have at least 1 column.");
 		return 0;
 	}
 

--- a/MASH-FRET/source/mod-transition-analysis/c-code/trainPH.h
+++ b/MASH-FRET/source/mod-transition-analysis/c-code/trainPH.h
@@ -7,16 +7,34 @@
 #define MAXITER 100000 // maximum number of EM iterations
 
 
-bool optDPH(double* T, double* a, double* logL, const double* cnts, int J, int nDt);
-void EstepDPH(double* B, double* Nij, double* Ni, const double* P, const double* a, const double* T, const double* t, int nDt, int J, 
-		const int** id_T, const int** id_P, const int** id_Jh, const int** id_Jv, const int** id_mat);
-void MstepDPH(double* a, double* T, double* t, const double* B, const double* Nij, const double* Ni, double totCnt, int J, const int** id_T);
-double calcMaxDev(const double* T, const double* T_prev, const double* a,const double*  a_prev, int J);
-double calcDPHlogL(const double* T, const double* a, const double* t, const double* P, int J, int nDt, const int** id_T, const int** id_P, const int** id_v);
-double calcDPHlogL_2(const double* T, const double* a, const double* t, const double* B, const double* Nij, const double* Ni, 
+bool optDPH(double* T, double* t, double* a, double* logL, 
+        const double* cnts, int J, int nDt, int* nb);
+
+void EstepDPH(double* B, double* Nij, double* Ni, const double* P, 
+        const double* a, const double* T, const double* t, int nDt, int J, 
+		const int** id_T, const int** id_P, const int** id_Jh, 
+        const int** id_Jv, const int** id_mat, double* totCount);
+
+void MstepDPH(double* a, double* T, double* t, const double* B, 
+        const double* Nij, const double* Ni, double totCnt, int J, 
+        const int** id_T);
+
+double calcMaxDev(const double* T, const double* T_prev, const double* a,
+        const double*  a_prev, int J);
+
+double calcDPHlogL(const double* T, const double* a, const double* t, 
+        const double* P, int J, int nDt, const int** id_T, 
+        const int** id_P, const int** id_v);
+
+double calcDPHlogL_2(const double* T, const double* a, const double* t, 
+        const double* B, const double* Nij, const double* Ni, 
 		int J, const int** id_T);
+
 int eraseAndWrite(char* str, int nb);
-int dispDPHres(double m,double dL, double dmax, const double* T, const double* a, int J, const int** id_T, int nb);
+
+int dispDPHres(double m,double dL, double dmax, const double* T, 
+        const double* a, int J, const int** id_T, int nb);
+
 bool validArg(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]);
 
 

--- a/MASH-FRET/source/mod-transition-analysis/kinetic-model/MLDPH.m
+++ b/MASH-FRET/source/mod-transition-analysis/kinetic-model/MLDPH.m
@@ -1,0 +1,106 @@
+function [schmopt,mdl] = MLDPH(dt,T,sumexp,Dmax)
+
+% defaults
+schmstr = {'hyper exponential','erlang'};
+
+% ML-DPH inference: determine state degeneracy
+BIC_all = [];
+cvg_all = [];
+mdl = [];
+for D = 1:Dmax
+    fprintf(['for ', num2str(D),' states (%i max.):\n'],Dmax);
+
+    % collects hyperexponential and Erlang transition schemes
+    schm_D = collectstransscheme(D,'hypexp');
+    if (D>1 && ~sumexp)
+        schm_D = cat(3,schm_D,collectstransscheme(D,'erlang'));
+    end
+    
+    % test schemes one after the other
+    for s = 1:size(schm_D,3)
+        fprintf(['scheme ',schmstr{s},':\n']);
+        mdl_sD = script_inferPH(dt,T,schm_D(:,:,s),'');
+
+        % calculate BIC
+        nfp = sum(sum(mdl_sD.schm))-1;
+        mdl_sD.BIC = nfp*log(mdl_sD.N)-2*mdl_sD.logL;
+        
+        % check model divergence and state doublons
+        mdl_sD.cvg = isdphvalid(mdl_sD.tp_fit) & ~isdoublon(mdl_sD.tp_fit);
+        
+        % append results
+        mdl = cat(1,mdl,mdl_sD);
+        BIC_all = cat(2,BIC_all,mdl_sD.BIC);
+        cvg_all = cat(2,cvg_all,mdl_sD.cvg);
+    end
+end
+
+% model selection
+sopt = find(BIC_all==min(BIC_all(~~cvg_all)));
+schmopt = mdl(sopt(1)).schm;
+
+
+function cvg = isdphvalid(tp)
+
+cvg = false;
+if isempty(tp) || any(tp(~~eye(size(tp)))<exp(-0.5))
+    return
+end
+
+cvg = true;
+
+
+function dbl = isdoublon(tp)
+
+% defaults
+maxdiff = 1E-4; % maximum transition probability gap between different states
+
+dbl = false;
+V = size(tp,1);
+for v1 = 1:V
+    for v2 = 1:V
+        if v2==v1
+            continue
+        end
+        vs = 1:V;
+        vs([v1,v2]) = [];
+        maxdiff12 = max(abs(tp(v1,[v1,vs])-tp(v2,[v2,vs])));
+        if maxdiff12<maxdiff
+            dbl = true;
+            return
+        end
+    end
+end
+
+
+function schm = collectstransscheme(D,type)
+% schm = collectstransscheme(D,type)
+%
+% D: number of states
+% type: 'hypexp', 'erlang' or 'all'
+% schm: transition scheme
+
+switch type
+    case 'hypexp'
+        ip = ones(1,D);
+        ep = ones(D,1);
+        tp = zeros(D);
+        
+    case 'erlang'
+        ip = [1,zeros(1,D-1)];
+        ep = [zeros(D-1,1);1];
+        tp = zeros(D);
+        for d = 1:D-1
+            tp(d,d+1) = 1;
+        end
+        
+    otherwise % all
+        ip = [1,zeros(1,D-1)];
+        ep = [zeros(D-1,1);1];
+        tp = ones(D);
+        tp(~~eye(D)) = 0;
+end
+
+schm = [0,ip,0; zeros(D,1),tp,ep; zeros(1,D+2)];
+
+

--- a/MASH-FRET/source/mod-transition-analysis/kinetic-model/getCombinations.m
+++ b/MASH-FRET/source/mod-transition-analysis/kinetic-model/getCombinations.m
@@ -1,0 +1,14 @@
+function cmb = getCombinations(js,vs)
+
+cmb = [];
+for v = 1:numel(vs)
+    if v>1
+        cmb_add = [];
+        for j = 1:numel(js)
+            cmb_add = cat(1,cmb_add,cat(2,cmb,repmat(js(j),size(cmb,1),1)));
+        end
+        cmb = cmb_add;
+    else
+        cmb = js';
+    end
+end

--- a/MASH-FRET/source/mod-transition-analysis/kinetic-model/script_inferPH.m
+++ b/MASH-FRET/source/mod-transition-analysis/kinetic-model/script_inferPH.m
@@ -1,282 +1,147 @@
-function mdl = script_inferPH(dt,states,expT,dt_bin,n_rs,J_deg,plotIt,sumexp,savecurve)
-% mdl = script_inferPH(allSchemes,dt,expT,dt_bin,n_rs,J_deg,plotIt,sumexp,savecurve)
+function mdl = script_inferPH(dt,n_rs,schm,savecurve)
+% mdl = script_inferPH(dt,n_rs,schm,savecurve)
 %
 % Trains DPH distributions of specific complexities (in terms of number of degenerated levels) on experimental dwell time histograms (one histogram per state value).
 % Returns best fit parameters
 %
-% dt: [nDt-by-3] dwell times (s), molecule indexes, state values
-% states: [1-by-V] state values in dt
-% expT: bin time (s)
-% dt_bin: binning factor for dwell times prior building histogram
+% dt: [nDat-by-2] dwell times, count
 % n_rs: number of restarts
-% J_deg: [1-by-V] number of degenerated levels
-% plotIt: (1) to plot fit, (0) otherwise
-% sumexp: (1) to fit a sume of exponential (0) to fit PH
+% schm: [D+2-by-D+2] transition schemes to fit
 % savecurve: empty or destination folder to save best fit curves
 % mdl: structure containing fit DPH parameters
-%   mdl.pi_fit: {1-by-V} starting probabilities
-%   mdl.tp_fit: {1-by-V} transition probabilities among degenerated states of a same state value
-%   mdl.logL: {1-by-V} log likelihoods for best fits
-%   mdl.N: [1-by-V] number of data
-
-% initialize output
-mdl = struct;
+%   mdl.pi_fit: [1-by-D] starting probabilities
+%   mdl.tp_fit: [D-by-D+1] transition probabilities among degenerated states of a same state value
+%   mdl.logL: log likelihood
+%   mdl.N: number of bins in dwell tiem histogram
+%   mdl.schm: [D+2-by-D+2] transition scheme that was fit
 
 % defaults
 PH_type = 1;% 1 for discrete, 2 for continuous
 
+% control data sufficiency
+if isempty(dt)
+    mdl.pi_fit = 1;
+    mdl.tp_fit = [1,0];
+    mdl.logL = -Inf;
+    mdl.N = 0;
+    mdl.schm = schm;
+    fprintf('no dwell time left for ML-DPH\n');
+    return
+end
+
+% collect DPH fit curve export
 saveit = ~isempty(savecurve);
+
+% get data mensurations
+D = size(schm,1)-2;
+x = dt(:,1)';
+P = dt(:,2)';
+nDat = sum(P);
+incl = (x>0 & P>0);
+
+% ML-DPH inference
+logL = -Inf;
+a_fit = [];
+T_fit = [];
+rs = 1;
+rs0 = 0;
+while rs<=n_rs
+    if rs0~=rs
+        fprintf(['restart ',num2str(rs),'/',num2str(n_rs),': ']);
+        rs0 = rs;
+    end
+
+    % random starting guess for initial probabilities
+    a_start = double(schm(1,2:end-1));
+    a_start = a_start/sum(a_start);
+    
+    % random starting guess for transition probabilities
+    if PH_type==2 % continuous PH
+        w0 = rand(D,D+1);
+        w0(~schm(2:end-1,2:end)) = 0;
+        w0 = w0./repmat(sum(w0,2),[1,D+1]);
+
+        r0 = rand(D,1);
+
+        T_start = w0.*repmat(r0,[1,D+1]);
+        t_start = T_start(:,end);
+        T_start = T_start(:,1:D);
+        T_start(~~eye(D)) = -(sum(T_start,2)+t_start);
+    end
+
+    if PH_type==1 % discrete PH
+        tp0 = rand(D,D+1);
+        tp0(~schm(2:end-1,2:end)) = 0;
+        tp0(~~eye(size(tp0))) = 10;
+        tp0 = tp0./repmat(sum(tp0,2),[1,D+1]);
+
+        t_start = tp0(:,D+1);
+        T_start = tp0(:,1:D);
+    end
+
+    % train a PH model on experimental CDF
+    [a_res,T_res,logL_res,nb_res] = ...
+        trainPH(a_start,T_start,t_start,[x(incl);P(incl)]);
+    if isinf(logL_res) || isempty(a_res) || isempty(T_res)
+        dispProgress('',nb_res);
+        continue
+    end
+    rs = rs+1;
+    if logL_res>logL
+        logL = logL_res;
+        a_fit = a_res;
+        T_fit = T_res;
+    end
+end
+
+if isempty(a_fit) || isempty(T_fit)
+    mdl.pi_fit = [];
+    mdl.tp_fit = [];
+    mdl.logL = Inf;
+    mdl.N = nDat;
+    mdl.schm = schm;
+    return
+end
+
+% export hitstogram and DPH fit curve to ASCII file
+v_e = ones(D,1);
 if saveit
-    pname = savecurve;
-    if ~strcmp(pname(end),filesep)
-        pname = [pname,filesep];
-    end
-    if ~exist(pname,'dir')
-        mkdir(pname)
-    end
-end
-
-expT_bin = dt_bin*expT;
-n = 0;
-degen = cell(1,numel(J_deg));
-for j = 1:numel(J_deg)
-    degen{j} = [];
-    for j2 = 1:J_deg(j)
-        n = n+1;
-        degen{j} = [degen{j} n];
-    end
-end
-dt(:,1) = round(dt(:,1)/expT_bin);
-
-% calculate experimental complementary CDF for each state value z
-V = numel(states);
-P = cell(1,V);
-x = P;
-for v = 1:V
-    dt_z = dt(dt(:,3)==v,1);
-    if isempty(dt_z)
-        continue
-    end
-    edg = 0.5:(max(dt_z)+0.5);
-    x{v} = mean([edg(2:end);edg(1:end-1)],1);
-    P{v} = histcounts(dt_z,edg);
-end
-
-% calculate phase-type complementary CDF for each state value z
-pi_fit = cell(1,V);
-tp_fit = pi_fit;
-logL = -Inf(1,V);
-nDat = zeros(1,V);
-if plotIt || saveit
-    P_fit = pi_fit;
-    w_fit = pi_fit;
-    tau_fit = pi_fit;
-end
-for v = 1:V
-    if isempty(P{v})
-        pi_fit{v} = 1;
-        tp_fit{v} = [1,0];
-        fprintf('state %i/%i: trap state (irreversible transition)\n',v,V);
-        continue
-    end
-    
-    v_e = ones(J_deg(v),1);
-
-    pi_fit{v} = NaN(1,J_deg(v));
-    tp_fit{v} = NaN(J_deg(v),J_deg(v)+1);
-    if plotIt || saveit
-        L = numel(x{v});
-        P_fit{v} = zeros(1,L);
-        tau_fit{v} = NaN(J_deg(v),1);
-        w_fit{v} = NaN(J_deg(v)+1,J_deg(v)+1);
-    end
-    
-    incl = (x{v}>0 & P{v}>0);
-
-    % generate random PH parameters
-    a_fit = [];
-    T_fit = [];
-    for rs = 1:n_rs
-        
-        fprintf('state %i/%i, restart %i/%i: ',v,V,rs,n_rs);
-
-        % use random starting guess
-        a_start = ones(1,J_deg(v));
-        a_start = a_start/sum(a_start);
-
-        if PH_type==2 % continuous PH
-            w0 = rand(J_deg(v),J_deg(v)+1);
-            w0([~~eye(J_deg(v)) false(J_deg(v),1)]) = 0;
-            w0 = w0./repmat(sum(w0,2),[1,J_deg(v)+1]);
-
-            r0 = rand(J_deg(v),1);
-
-            T_start = w0.*repmat(r0,[1,J_deg(v)+1]);
-            t = T_start(:,end);
-            T_start = T_start(:,1:J_deg(v));
-            T_start(~~eye(J_deg(v))) = -(sum(T_start,2)+t);
-        end
-
-        if PH_type==1 % discrete PH
-            tp0 = rand(J_deg(v),J_deg(v)+1);
-            if sumexp
-                for j = 1:J_deg(v)
-                    tp0(j,1:J_deg(v)) = 0;
-                end
-            end
-            tp0(~~eye(size(tp0))) = 10;
-            tp0 = tp0./repmat(sum(tp0,2),[1,J_deg(v)+1]);
-
-            T_start = tp0(:,1:J_deg(v));
-        end
-
-        % train a PH model on experimental CDF
-        [a_res,T_res,logL_res] = ...
-            trainPH(a_start,T_start,[x{v}(incl);P{v}(incl)]);
-%         [a_res,T_res,logL_res] = trainPH_matlab(PH_type,a_start,...
-%             T_start,[x{v}(incl);P{v}(incl)]);
-        if isempty(a_res) || isempty(T_res)
-%             disp(['Optimization failed: ' errstr]);
-            continue
-        end
-        if logL_res>logL(v)
-            logL(v) = logL_res;
-            a_fit = a_res;
-            T_fit = T_res;
-        end
-    end
-    if isempty(a_fit) || isempty(T_fit)
-        if plotIt || saveit
-            P_fit{v}(1,:) = 0;
-        end
-        continue
-    end
-    
-    if plotIt || saveit
+    L = numel(x);
+    P_fit = zeros(1,L);
+    if ~(isempty(a_fit) || isempty(T_fit))
         if PH_type==1 % discrete PH
             t = v_e-T_fit*v_e;
         end
         for l = 1:L
             if PH_type==1 % discrete PH
-                P_fit{v}(1,l) = a_fit*(T_fit^(x{v}(l)-1))*t;
+                P_fit(1,l) = a_fit*(T_fit^(x(l)-1))*t;
             else% continuous PH
-                P_fit{v}(1,l) = a_fit*expm(T_fit*x{v}(l))*v_e;
+                P_fit(1,l) = a_fit*expm(T_fit*x(l))*v_e;
             end
         end
     end
-    if saveit
-        % export hitstogram and DPH fit curve
-        dat = [x{v}',P{v}',P_fit{v}'];
-        rname = sprintf('state%0.1f_D%i',states(v),J_deg(v));
-        nf = 1;
-        ffile = [pname,rname,'_dphplot'];
-        while exist(ffile,'file')
-            nf = nf+1;
-            ffile = [pname,rname,'(',num2str(nf),')_dphplot'];
-        end
-        save(ffile,'dat','-ascii')
-    end
-
-    % get parameters from trained PH model
-    pi_fit{v} = a_fit;
-    if PH_type==2 % continuous PH
-        r_v = -diag(T_fit)/dt_bin;
-        w = T_fit./repmat(r_v,1,J_deg(v));
-        w(~~eye(J_deg(v))) = 0;
-        w = cat(2,w,1-sum(w,2));
-    else % discrete PH
-        t = v_e-T_fit*v_e;
-%         r_v = -log(diag(T_fit))/dt_bin;
-        k = [T_fit,t];
-        k(~~eye(J_deg(v))) = 0;
-        r_v = sum(k,2)/dt_bin;
-        w = k./repmat(sum(k,2),[1,J_deg(v)+1]);
-    end
-    tp_fit{v} = w.*repmat(r_v,[1,J_deg(v)+1]);
-    tp_fit{v}(~~eye(J_deg(v))) = 1-sum(tp_fit{v},2);
-    if plotIt
-        tau_fit{v} = expT./r_v;
-        w_fit{v} = w;
-    end
-%     nDat(v) = sum(x{v}.*P{v});
-    nDat(v) = sum(P{v});
+    dat = [x',P',P_fit'];
+    save(savecurve,'dat','-ascii')
 end
-mdl.pi_fit = pi_fit;
+
+% get DPH transition probabilities
+if PH_type==2 % continuous PH
+    r = -diag(T_fit)/dt_bin;
+    w = T_fit./repmat(r,1,D);
+    w(~~eye(D)) = 0;
+    w = cat(2,w,1-sum(w,2));
+    tp_fit = w.*repmat(r,[1,D+1]);
+    tp_fit(~~eye(D)) = 1-sum(tp_fit,2);
+    
+else % discrete PH
+    t = v_e-T_fit*v_e;
+    tp_fit = [T_fit,t];
+end
+
+% return results
+mdl.pi_fit = a_fit;
 mdl.tp_fit = tp_fit;
 mdl.logL = logL;
 mdl.N = nDat;
-
-% plot experimental and calculated distributions
-if plotIt
-    hfig = figure('color','white');
-    hfig.Position = [hfig.Position([1,2]),2*hfig.Position(3),hfig.Position(4)];
-    switch PH_type
-        case 1
-            PH_type_str = 'discrete';
-        case 2
-            PH_type_str = 'continuous';
-    end
-    
-    existPlot = false;
-    for v = 1:V
-        ha1 = subplot(1,2*V,2*v-1);
-        xlabel(ha1,sprintf('dwell time is state %i (seconds)',v));
-        if v==1
-            ylabel(ha1,'PDF');
-        end
-        ha2 = subplot(1,2*V,2*v);
-        xlabel(ha2,sprintf('dwell time is state %i (seconds)',v));
-        if v==V
-            hst = sgtitle(['Dwell time histograms and respective ',...
-                PH_type_str,' PH distribution']);
-            hst.FontSize = 12;
-        end
-        if isempty(P{v})
-            continue
-        end
-        
-        ha1.NextPlot = 'add';
-        plot(ha1,expT_bin*x{v},P{v},'color','black','linewidth',1);
-        plot(ha1,expT_bin*x{v},sum(P{v})*P_fit{v},'color','blue',...
-            'linewidth',1);
-        ha1.YLim = [0,max(P{v})];
-        if ~existPlot
-            legend(ha1,'data','fit');
-            existPlot = true;
-        end
-
-        ha2.NextPlot = 'add';
-        ha2.YScale = 'log';
-        plot(ha2,expT_bin*x{v},P{v},'color','black','linewidth',2);
-        plot(ha2,expT_bin*x{v},sum(P{v})*P_fit{v},'color','blue',...
-            'linewidth',1);
-        if max(P{v})==1
-            ha2.YLim = [0.5,2];
-        else
-            ha2.YLim = [0.5,max(P{v})];
-        end
-
-        str_mat = 'w:\n';
-        str_mat = [str_mat,...
-            repmat([repmat('%0.2f  ',1,J_deg(v)),'%0.2f  \n'],[1,J_deg(v)+1])];
-        ht3 = text(ha2.XLim(2)/8,ha2.YLim(1)+(ha2.YLim(2)-ha2.YLim(1))*0.3,...
-            sprintf(str_mat,w_fit{v}'),'color','blue');
-
-        str_tau = 'tau (s)\n';
-        str_tau = [str_tau,repmat('%0.2f\n',1,J_deg(v))];
-        ht4 = text(sum(ht3.Extent([1,3])),ht3.Position(2),...
-            sprintf(str_tau,tau_fit{v}),'color','blue',...
-            'fontweight','bold');
-        
-        str_pi = 'pi\n';
-        str_pi = [str_pi,repmat('%0.2f\n',1,J_deg(v))];
-        text(sum(ht4.Extent([1,3])),ht4.Position(2),...
-            sprintf(str_pi,pi_fit{v}),'color','blue',...
-            'fontweight','bold');
-
-        str_logL = sprintf('logL=%0.6f',logL(v));
-        text(ha2.XLim(2)/2,ha2.YLim(1)+(ha2.YLim(2)-ha2.YLim(1))*0.07,...
-            str_logL,'color','blue','fontweight','bold');
-    end
-end
+mdl.schm = schm;
 


### PR DESCRIPTION
Modifies ML-DPH and ML-BW as it is in the article in preparation:
- ML-DPH was testing only one state connectivity where all states transitions were possible: this led to an underestimation of the state degeneracy as the penalty was always maximum. We found that all state connectivities are equivalent to either the **hyperexponential** (sum of exponential distributions) or the **irreversible loop** (Erlang distribution) connectivity schemes. For each state degeneracy value, ML-DPH is now testing these two connectivity schemes. This yields more accurate solving of the state degeneracy.
- ML-BW was yielding the maximum-likelihood estimate of the transition probability matrix, which gave an irrelevant state connectivity. We've implemented the **hierarchical search** of the most simple and equivalent state connectivity scheme by recursively forbidding transitions that have a probability lower than epsilon.