### PR TITLE
fix error occurring when exporting data from Simulation

### DIFF
--- a/MASH-FRET/.release_version.json
+++ b/MASH-FRET/.release_version.json
@@ -1,4 +1,4 @@
 {
 "tag" : "1.3.3.1",
-"prev_commit_hash" : "8d24803a"
+"prev_commit_hash" : "34516871"
 }

--- a/MASH-FRET/source/mod-simulation/export-options/exportResults.m
+++ b/MASH-FRET/source/mod-simulation/export-options/exportResults.m
@@ -88,6 +88,10 @@ discr_blurr = permute(prm.res_dat{2}(:,1,:),[1,3,2]);
 discr = permute(prm.res_dat{2}(:,2,:),[1,3,2]);
 discr_seq = permute(prm.res_dat{2}(:,3,:),[1,3,2]);
 
+% correct for negative detection
+Idon(Idon<0) = 0;
+Iacc(Iacc<0) = 0;
+
 L = size(Idon,1);
 dat = p.proj{proj};
 dat.FRET_DTA = discr;

--- a/MASH-FRET/source/mod-simulation/video-parameters/rand_NexpN.m
+++ b/MASH-FRET/source/mod-simulation/video-parameters/rand_NexpN.m
@@ -70,7 +70,6 @@ for i = 1:numel(dat_val)
               % cancelled by MH, 2.4.2019
 %               mu_ref = mu;
 %         end
-
         dat(dat==mu) = randsample(x, numel(dat(dat==mu)), true, P);
         
     else


### PR DESCRIPTION
Epsilon-negative photon trajectories were input to the Nexp-N noise generator, which was yielding a MATLAB error. In this branch, negative values in photon-count trajectories are replaced by 0 before any processing is made to it. 

Fixes #100 