### PR TITLE
Allows math expressions in online doc with mathjax3

### DIFF
--- a/MASH-FRET/.release_version.json
+++ b/MASH-FRET/.release_version.json
@@ -1,4 +1,4 @@
 {
 "tag" : "1.3.3.2",
-"prev_commit_hash" : "fc6b8106"
+"prev_commit_hash" : "312ec060"
 }

--- a/docs/_includes/head_custom.html
+++ b/docs/_includes/head_custom.html
@@ -1,8 +1,80 @@
-{% if page.mathjax %}
-  <script type="text/x-mathjax-config">
-    {{ site.mathjax.config }};
-  </script>
-  <script type="text/javascript" async 
-    src="{{ site.mathjax.source }}">
-  </script>
-{% endif %}
+{%- comment -%}
+  MathJax: See https://docs.mathjax.org/en/v2.7-latest/start.html
+  
+  For loading and configuration to use version 3, see:
+  https://docs.mathjax.org/en/latest/web/configuration.html
+{%- endcomment -%}
+
+{% case page.math %}
+
+  {% when "katex" %}
+  
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.13/dist/katex.min.css" crossorigin="anonymous">
+
+    <!-- The loading of KaTeX is deferred to speed up page rendering -->
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.13/dist/katex.min.js" crossorigin="anonymous"></script>
+
+    <!-- To automatically render math in text elements, include the auto-render extension: -->
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.13/dist/contrib/auto-render.min.js" crossorigin="anonymous"
+    onload="renderMathInElement(document.body, {
+      globalGroup: true,
+      trust: true,
+      strict: false,
+      throwOnError: false,
+      macros: {
+        '\\\n': '\\ '
+      }
+    });"></script>
+
+    <!-- Override the KaTeX default of font-size: 1.21em -->
+    <style>
+      .katex { 
+        font-size: 1em; 
+      }
+    </style>
+
+    <!-- Potential workaround for KaTeX 0.13 bug https://github.com/KaTeX/KaTeX/issues/2815 -->
+    <style>
+      .katex .vlist-t2 > .vlist-r:nth-child(2) > .vlist {
+        pointer-events: none;
+    }
+    </style>
+     
+  {% when "mathjax2" %}
+  
+    <script type="text/x-mathjax-config">
+      MathJax.Hub.Config({
+        TeX: { 
+          equationNumbers: { autoNumber: "AMS" }
+        }
+      });
+    </script>
+    <script type="text/javascript" async 
+      src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.7/latest.js?config=TeX-AMS_SVG">
+    </script>
+  
+  {% when "mathjax3" %}
+    
+    <script>
+      MathJax = { 
+        tex: { 
+          tags: 'ams',
+          packages: {'[+]': ['textmacros']},
+        },
+        loader: {
+          load: ['[tex]/textmacros']
+        }
+      };
+    </script>
+    <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+    <script type="text/javascript" id="MathJax-script" async
+      src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js">
+    </script>
+
+{% endcase %}
+
+{%- comment -%}
+  Favicon: See https://stackoverflow.com/questions/1321878/how-to-prevent-favicon-ico-requests
+{%- endcomment -%}
+
+<link rel="icon" href="data:,">

--- a/docs/trace-processing/functionalities/tm-automatic-sorting.md
+++ b/docs/trace-processing/functionalities/tm-automatic-sorting.md
@@ -9,7 +9,7 @@ nav_order: 3
 subnav_order: 2
 nav_exclude: true
 toc_exclude: true
-mathjax: true
+math: mathjax3
 ---
 
 <img src="../../assets/images/logos/logo-trace-processing_400px.png" width="170" style="float:right; margin-left: 15px;"/>
@@ -86,7 +86,7 @@ The type of data sets can be selected in menu **(b)** (x-axis) and **(g)** (y-ax
 * `mean dwell time (molecule-wise)` for the average state dwell times of the state trajectories
 * `state values (state-wise)` for the individual state values in the state trajectories
 * `state dwell times (state-wise)` for the individual state dwell times in the state trajectories
-* `state lifetimes (state-wise)` for the individual state lifetimes $$\tau$$ estimated from transition numbers $$N_{ij}$$ and trajectory length $$L$$ with: $$\tau_i=\frac{L}{\sum_{j \neq \i} N_{ij}}$$
+* `state lifetimes (state-wise)` for the individual state lifetimes $$\tau$$ estimated from transition numbers $$N_{ij}$$ and trajectory length $$L$$ with: $$\tau_i=\frac{L}{\sum_{j \neq i} N_{ij}}$$
 
 For 2D-sorting, x-axis and y-axis data sets must occur on the same scale (`frame-wise`, `molecule-wise` or `state-wise`).
 


### PR DESCRIPTION
Configure file `_config.yml ` and `_includes/head_custom.html` to render math expression with MathJax 3 in online doc.
To activate MathJax rendering, add to the front matter:

```md
math: mathjax3
```