### PR TITLE
Correct exclusion of doublon coordinates after channel transformation.

### DIFF
--- a/MASH-FRET/.release_version.json
+++ b/MASH-FRET/.release_version.json
@@ -1,4 +1,4 @@
 {
 "tag" : "1.3.3.3",
-"prev_commit_hash" : "cb732345"
+"prev_commit_hash" : "6fc72c9b"
 }

--- a/MASH-FRET/source/mod-video-processing/coordinates/exclude_doublecoord.m
+++ b/MASH-FRET/source/mod-video-processing/coordinates/exclude_doublecoord.m
@@ -16,10 +16,9 @@ for j = 1:size(coord,1)-1
     if ~ok(j,1)
         continue
     end
-    isdbl = id~=j & abs(coord(j,1:2:end)-coord(:,1:2:end))<tol & ...
-        abs(coord(j,2:2:end)-coord(:,2:2:end))<tol;
+    isdbl = id~=j & any(abs(coord(j,1:2:end)-coord(:,1:2:end))<tol & ...
+        abs(coord(j,2:2:end)-coord(:,2:2:end))<tol,2);
     if any(isdbl)
-        ok(j,1) = false;
         ok(isdbl',1) = false;
     end
 %     for i = j+1:size(coord,1)


### PR DESCRIPTION
* Due to recent modifications (commit f4f3fd9) to accelerate exclusion of doublons coordinates, the process was corrupted. It is now running correctly.

May fix #114 