### PR TITLE
Handle error when an .avi file is used for intensity integration

### DIFF
--- a/MASH-FRET/.release_version.json
+++ b/MASH-FRET/.release_version.json
@@ -1,4 +1,4 @@
 {
 "tag" : "1.3.3.3",
-"prev_commit_hash" : "cb732345"
+"prev_commit_hash" : "6fc72c9b"
 }

--- a/MASH-FRET/source/mod-video-processing/create-traces/create_trace.m
+++ b/MASH-FRET/source/mod-video-processing/create-traces/create_trace.m
@@ -1,6 +1,6 @@
-function [coord,trace] = create_trace(coord, aDim, nPix, fDat,varargin)
-% [coord,trace] = create_trace(coord, aDim, nPix, fDat)
-% [coord,trace] = create_trace(coord, aDim, nPix, fDat, mute)
+function [coord,trace,err] = create_trace(coord, aDim, nPix, fDat,varargin)
+% [coord,trace,err] = create_trace(coord, aDim, nPix, fDat)
+% [coord,trace,err] = create_trace(coord, aDim, nPix, fDat, mute)
 %
 % Sort out single molecule coordinates and create corresponding intensity-time trace.
 % Intensities are calculated as the sum of the brightest pixels in a square zone around the molecule coordinates.
@@ -15,6 +15,7 @@ function [coord,trace] = create_trace(coord, aDim, nPix, fDat,varargin)
 %  fDat{4}: video length (in frames)
 % mute: (1) to mute actions, (0) otherwise
 % trace: [L-by-N*nChan] intensity-time traces
+% err: error message if any
 
 res_y = fDat{3}(1);
 res_x = fDat{3}(2);
@@ -56,9 +57,9 @@ for c = 1:nCoord
 end
 if ~isempty(varargin)
     mute = varargin{1};
-    trace = getIntTrace(lim, aDim, nPix, fDat, mute);
+    [trace,err] = getIntTrace(lim, aDim, nPix, fDat, mute);
 else
-    trace = getIntTrace(lim, aDim, nPix, fDat);
+    [trace,err] = getIntTrace(lim, aDim, nPix, fDat);
 end
 
              

--- a/MASH-FRET/source/mod-video-processing/create-traces/getIntTrace.m
+++ b/MASH-FRET/source/mod-video-processing/create-traces/getIntTrace.m
@@ -1,6 +1,6 @@
-function trace = getIntTrace(lim, aDim, nPix, fDat, varargin)
-% trace = getIntTrace(lim, aDim, nPix, fDat)
-% trace = getIntTrace(lim, aDim, nPix, fDat, mute)
+function [trace,err] = getIntTrace(lim, aDim, nPix, fDat, varargin)
+% [trace,err] = getIntTrace(lim, aDim, nPix, fDat)
+% [trace,err] = getIntTrace(lim, aDim, nPix, fDat, mute)
 %
 % Inegrate intensities for specific positions in the fDat{2}{2}eo and build up corresponding intensity-time traces.
 % Intensities are calculated as the sum of the brightest pixels in a square zone around the molecule coordinates.
@@ -16,6 +16,8 @@ function trace = getIntTrace(lim, aDim, nPix, fDat, varargin)
 %  fDat{3}: [1-by-2] fDat{2}{2}eo dimensions in the x- and y- directions
 %  fDat{4}: fDat{2}{2}eo length (in frames)
 % mute: (1) to mute actions, (0) otherwise
+% trace: [L-by-N] intensities
+% err: error message if any
 
 % defaults
 nbytes = 0;
@@ -85,6 +87,7 @@ switch fext
         end
         f = fopen(movFile, 'r');
         if f < 0 
+            err = 'Could not open the .sif file.';
             errordlg('Could not open the file.');
             return;
         end
@@ -290,6 +293,7 @@ switch fext
         end
         f = fopen(movFile, 'r');
         if f < 0 
+            err = 'Could not open the .pma file.';
             errordlg('Could not open the file.');
         else
             prev = 0;
@@ -332,8 +336,9 @@ switch fext
         return
         
     otherwise
-        disp(['Video format ',fext,...
-            ' is not supported for intensity integration.'])
+        err = ['Video format ',fext,...
+            ' is not supported for intensity integration.'];
+        disp(err)
         return
 end
 

--- a/MASH-FRET/source/project/exportProject.m
+++ b/MASH-FRET/source/project/exportProject.m
@@ -44,6 +44,7 @@ for mov = 1:nMov
         guidata(h_fig,h);
         [dat,ok] = getFrames(vidfile{mov},'all',viddat{mov},h_fig,true);
         if ~ok
+            proj = [];
             return
         end
         h = guidata(h_fig);
@@ -72,10 +73,20 @@ for mov = 1:nMov
 
     % build traces
     if multichanvid
-        [coordsm,traces] = create_trace(coordsm0,pxdim,npix,fDat);
+        [coordsm,traces,err] = create_trace(coordsm0,pxdim,npix,fDat);
+        if isempty(traces)
+            setContPan(['No trace created: ',err],'error',h_fig);
+            proj = [];
+            return
+        end
     else
-        [coordsm_mv{mov},traces_mv{mov}] = create_trace(...
+        [coordsm_mv{mov},traces_mv{mov},err] = create_trace(...
             coordsm0(:,2*mov-1:2*mov),pxdim,npix,fDat);
+        if isempty(traces_mv{mov})
+            setContPan(['No trace created: ',err],'error',h_fig);
+            proj = [];
+            return
+        end
         ncoord = size(coordsm_mv{mov},1);
         idcoord{mov} = zeros(1,ncoord);
         for c = 1:ncoord


### PR DESCRIPTION
When an .avi file was used in Video processing to create intensity trajectories, a MATLAB error was terminating the process. To prevent such a crash, the error is now handle by an error message in the action panel.

Fixes #121 