### PR TITLE
Prevent and handle errors due to out-of-range project index

### DIFF
--- a/MASH-FRET/source/mod-simulation/_callbacks/edit_bgInt_acc_Callback.m
+++ b/MASH-FRET/source/mod-simulation/_callbacks/edit_bgInt_acc_Callback.m
@@ -1,9 +1,9 @@
 function edit_bgInt_acc_Callback(obj, evd, h_fig)
 
 % retrieve acceptor background intensity from edit field
-val = str2num(get(obj, 'String'));
+val = str2double(get(obj, 'String'));
 set(obj, 'String', num2str(val));
-if ~(~isempty(val) && numel(val) == 1 && ~isnan(val) && val >= 0)
+if ~(~isempty(val) && isscalar(val) && ~isnan(val) && val >= 0)
     set(obj, 'BackgroundColor', [1 0.75 0.75]);
     setContPan('Intensities must be >= 0', 'error', h_fig);
     return
@@ -22,7 +22,11 @@ noiseprm = curr.gen_dat{1}{2}{5};
 % convert intensity units
 if strcmp(inun, 'electron')
     [offset,K,eta] = getCamParam(noisetype,noiseprm);
-    val = ele2phtn(val,K,eta);
+    pc = ele2phtn(val,K,eta);
+    setContPan(['given the camera settings, ',num2str(val),' electron counts ',...
+        'approaches ',num2str(pc),' photon counts, which is exactly ',...
+        'converted to ',num2str(phtn2ele(pc,K,eta)),'.'],'success',h_fig);
+    val = pc;
 end
 if perSec
     val = val/rate;

--- a/MASH-FRET/source/mod-simulation/_callbacks/edit_bgInt_don_Callback.m
+++ b/MASH-FRET/source/mod-simulation/_callbacks/edit_bgInt_don_Callback.m
@@ -1,9 +1,9 @@
 function edit_bgInt_don_Callback(obj, evd, h_fig)
 
 % retrieve donor background intensity from edit field
-val = str2num(get(obj, 'String'));
+val = str2double(get(obj, 'String'));
 set(obj, 'String', num2str(val));
-if ~(~isempty(val) && numel(val) == 1 && ~isnan(val) && val >= 0)
+if ~(~isempty(val) && isscalar(val) && ~isnan(val) && val >= 0)
     set(obj, 'BackgroundColor', [1 0.75 0.75]);
     setContPan('Intensities must be >= 0', 'error', h_fig);
     return
@@ -22,7 +22,11 @@ noiseprm = curr.gen_dat{1}{2}{5};
 % convert intensity units
 if strcmp(inun, 'electron')
     [offset,K,eta] = getCamParam(noisetype,noiseprm);
-    val = ele2phtn(val,K,eta);
+    pc = ele2phtn(val,K,eta);
+    setContPan(['given the camera settings, ',num2str(val),' electron counts ',...
+        'approaches ',num2str(pc),' photon counts, which is exactly ',...
+        'converted to ',num2str(phtn2ele(pc,K,eta)),'.'],'success',h_fig);
+    val = pc;
 end
 if perSec
     val = val/rate;

--- a/MASH-FRET/source/mod-simulation/_callbacks/edit_totInt_Callback.m
+++ b/MASH-FRET/source/mod-simulation/_callbacks/edit_totInt_Callback.m
@@ -1,9 +1,9 @@
 function edit_totInt_Callback(obj, evd, h_fig)
 
 % retrieve intensity value from edit field
-val = str2num(get(obj, 'String'));
+val = str2double(get(obj, 'String'));
 set(obj, 'String', num2str(val));
-if ~(~isempty(val) && numel(val) == 1 && ~isnan(val) && val >= 0)
+if ~(~isempty(val) && isscalar(val) && ~isnan(val) && val >= 0)
     set(obj, 'BackgroundColor', [1 0.75 0.75]);
     setContPan('Intensities must be >= 0', 'error', h_fig);
     return
@@ -22,7 +22,11 @@ inun = curr.gen_dat{3}{2};
 % convert intensity units
 if strcmp(inun, 'electron')
     [offset,K,eta] = getCamParam(noisetype,noiseprm);
-    val = ele2phtn(val,K,eta);
+    pc = ele2phtn(val,K,eta);
+    setContPan(['given the camera settings, ',num2str(val),' electron counts ',...
+        'approaches ',num2str(pc),' photon counts, which is exactly ',...
+        'converted to ',num2str(phtn2ele(pc,K,eta)),'.'],'success',h_fig);
+    val = pc;
 end
 if perSec
     val = val/rate;

--- a/MASH-FRET/source/mod-trace-processing/_callbacks/pushbutton_TM_Callback.m
+++ b/MASH-FRET/source/mod-trace-processing/_callbacks/pushbutton_TM_Callback.m
@@ -1,5 +1,9 @@
 function pushbutton_TM_Callback(obj, evd, h_fig)
 
+% adjust current project index in case it is out of list range (can happen 
+% when project import failed)
+setcurrproj(h_fig);
+
 % display process
 setContPan('Opening Trace manager...','process',h_fig);
 

--- a/MASH-FRET/source/mod-trace-processing/_callbacks/pushbutton_expTraces_Callback.m
+++ b/MASH-FRET/source/mod-trace-processing/_callbacks/pushbutton_expTraces_Callback.m
@@ -5,6 +5,10 @@ function pushbutton_expTraces_Callback(obj, evd, h_fig)
 % h_fig: handle to main figure
 % makeVisible = {1-by-1} (1) make option figure visible, (0) otherwise
 
+% adjust current project index in case it is out of list range (can happen 
+% when project import failed)
+setcurrproj(h_fig);
+
 % show process
 setContPan('Opening export options...','process',h_fig);
 

--- a/MASH-FRET/source/mod-trace-processing/management/ud_trSetTbl.m
+++ b/MASH-FRET/source/mod-trace-processing/management/ud_trSetTbl.m
@@ -34,7 +34,7 @@ addOn = get(h.togglebutton_TP_addTag,'value');
 if addOn
     str_lst = getStrPopTags(tagNames,colorlist);
     set(h.listbox_TP_defaultTags,'visible','on','string',str_lst);
-    if numel(str_lst)==1 && strcmp(str_lst{1},'no default tag')
+    if isscalar(str_lst) && strcmp(str_lst{1},'no default tag')
         set(h.listbox_TP_defaultTags,'value',1);
     else
         currTag = get(h.listbox_TP_defaultTags,'value');
@@ -63,9 +63,9 @@ for t = 1:nTag
         else
             fntClr = 'white';
         end
-        str_pop = [str_pop,cat(2,'<html><body  bgcolor="',colorlist{t},...
+        str_pop = cat(2,str_pop,cat(2,'<html><body  bgcolor="',colorlist{t},...
             '"><font color=',fntClr,'>',tagNames{t},...
-            '</font></body></html>')];
+            '</font></body></html>'));
     end
 end
 if isempty(str_pop)

--- a/MASH-FRET/source/project/_callbacks/listbox_projLst_Callback.m
+++ b/MASH-FRET/source/project/_callbacks/listbox_projLst_Callback.m
@@ -1,12 +1,16 @@
 function listbox_projLst_Callback(obj, evd, h_fig)
 
+% adjust current project index in case it is out of list range (can happen 
+% when project import failed)
+setcurrproj(h_fig);
+
 h = guidata(h_fig);
 p = h.param;
 if isempty(p.proj)
     return
 end
 val = get(obj, 'Value');
-if numel(val)>1 || (numel(val)==1 && val==p.curr_proj)
+if ~isscalar(val) || (isscalar(val) && val==p.curr_proj)
     return
 end
 
@@ -27,7 +31,7 @@ cla(h.axes_hist1);
 cla(h.axes_hist2);
 
 % switch to proper module
-switchPan(eval(['h.togglebutton_',p.curr_mod{p.curr_proj}]),[],h_fig);
+switchPan(h.(['togglebutton_',p.curr_mod{p.curr_proj}]),[],h_fig);
 
 % bring project's current plot front
 bringPlotTabFront([p.sim.curr_plot(p.curr_proj),...

--- a/MASH-FRET/source/project/_callbacks/menu_projMenu_merge_Callback.m
+++ b/MASH-FRET/source/project/_callbacks/menu_projMenu_merge_Callback.m
@@ -1,5 +1,9 @@
 function menu_projMenu_merge_Callback(obj,evd,h_fig)
 
+% adjust current project index in case it is out of list range (can happen 
+% when project import failed)
+setcurrproj(h_fig);
+
 h = guidata(h_fig);
 p = h.param;
 if ~isModuleOn(p,'TP')

--- a/MASH-FRET/source/project/_callbacks/pushbutton_closeProj_Callback.m
+++ b/MASH-FRET/source/project/_callbacks/pushbutton_closeProj_Callback.m
@@ -5,6 +5,10 @@ function pushbutton_closeProj_Callback(obj, evd, h_fig, varargin)
 % h_fig: handle to main figure
 % mute: (1) to mute user confirmations and action display, (0) otherwise
 
+% adjust current project index in case it is out of list range (can happen 
+% when project import failed)
+setcurrproj(h_fig);
+
 h = guidata(h_fig);
 p = h.param;
 if isempty(p.proj)

--- a/MASH-FRET/source/project/_callbacks/pushbutton_editProj_Callback.m
+++ b/MASH-FRET/source/project/_callbacks/pushbutton_editProj_Callback.m
@@ -1,5 +1,9 @@
 function pushbutton_editProj_Callback(obj,evd,h_fig)
 
+% adjust current project index in case it is out of list range (can happen 
+% when project import failed)
+setcurrproj(h_fig);
+
 % retrieve interface content
 h = guidata(h_fig);
 p = h.param;

--- a/MASH-FRET/source/project/_callbacks/pushbutton_newProj_Callback.m
+++ b/MASH-FRET/source/project/_callbacks/pushbutton_newProj_Callback.m
@@ -6,6 +6,10 @@ function pushbutton_newProj_Callback(obj,evd,h_fig)
 % act: 1 (simulation), 2 (import video), 3 (import trajectories), 4 (import histogram)
 % h_fig: handle to main figure
 
+% adjust current project index in case it is out of list range (can happen 
+% when project import failed)
+setcurrproj(h_fig);
+
 % open data selector
 if isnumeric(evd) % call from test routine
     act = slctdatdlg(h_fig,evd);

--- a/MASH-FRET/source/project/_callbacks/pushbutton_openProj_Callback.m
+++ b/MASH-FRET/source/project/_callbacks/pushbutton_openProj_Callback.m
@@ -1,4 +1,4 @@
-function pushbutton_openProj_Callback(obj, evd, h_fig)
+function pushbutton_openProj_Callback(files, merged, h_fig)
 % pushbutton_openProj_Callback([],[],h_fig)
 % pushbutton_openProj_Callback(files,[],h_fig)
 % pushbutton_openProj_Callback([],merged,h_fig)
@@ -9,22 +9,26 @@ function pushbutton_openProj_Callback(obj, evd, h_fig)
 
 % created by MH, 23.2.2021
 
+% adjust current project index in case it is out of list range (can happen 
+% when project import failed)
+setcurrproj(h_fig);
+
 % get interface parameters
 h = guidata(h_fig);
 p = h.param;
 
 % get project data
-if iscell(evd) % from project merging
-    dat = evd{1};
+if iscell(merged) % from project merging
+    dat = merged{1};
     [dat,ok] = checkField(dat,'',h_fig);
     if ~ok
         return
     end
     
 else % from file
-    if iscell(obj) % called by test routine
-        pname = obj{1};
-        fname = obj{2};
+    if iscell(files) % called by test routine
+        pname = files{1};
+        fname = files{2};
         if ~strcmp(pname,filesep)
             pname = [pname,filesep];
         end
@@ -37,7 +41,7 @@ else % from file
         else
             defPth = p.folderRoot;
         end
-        [fname,pname,o] = uigetfile({'*.mash','MASH-FRET project files';...
+        [fname,pname,~] = uigetfile({'*.mash','MASH-FRET project files';...
             '*.*', 'All files(*.*)'},'Select project',defPth,'MultiSelect',...
             'on');
     end
@@ -69,7 +73,7 @@ else % from file
     end
     
     % display process
-    if numel(fname)==1
+    if isscalar(fname)
         setContPan(['Importing project from file: ',fname{1},' ...'],...
             'process',h_fig);
     else
@@ -142,7 +146,7 @@ guidata(h_fig,h);
 ud_TTprojPrm(h_fig);
 
 % switch to proper module
-switchPan(eval(['h.togglebutton_',p.curr_mod{p.curr_proj}]),[],h_fig);
+switchPan(h.(['togglebutton_',p.curr_mod{p.curr_proj}]),[],h_fig);
 
 % bring project's current plot front
 bringPlotTabFront([p.sim.curr_plot(p.curr_proj),...
@@ -153,7 +157,7 @@ bringPlotTabFront([p.sim.curr_plot(p.curr_proj),...
 updateFields(h_fig);
 
 % display action
-if ~iscell(evd)
+if ~iscell(merged)
     if size(fname,2) > 1
         str_files = 'files: ';
     else

--- a/MASH-FRET/source/project/_callbacks/pushbutton_saveProj_Callback.m
+++ b/MASH-FRET/source/project/_callbacks/pushbutton_saveProj_Callback.m
@@ -5,6 +5,10 @@ function pushbutton_saveProj_Callback(obj, evd, h_fig)
 % h_fig: handle to main figure
 % file_out: {1-by-2} destination folder and file name
 
+% adjust current project index in case it is out of list range (can happen 
+% when project import failed)
+setcurrproj(h_fig);
+
 h = guidata(h_fig);
 p = h.param;
 if isempty(p.proj)

--- a/MASH-FRET/source/project/adjustProjIndexLists.m
+++ b/MASH-FRET/source/project/adjustProjIndexLists.m
@@ -13,6 +13,13 @@ function p = adjustProjIndexLists(p,xn,mod)
 
 excl = false(size(p.sim.curr_plot));
 for x = 1:numel(xn)
+    
+    % handle case where project index is out of list range (can happen when
+    % project import failed)
+    if abs(xn(x))>numel(p.proj)
+        continue
+    end
+
     if xn(x)<0
         excl(-xn(x)) = true;
     else

--- a/MASH-FRET/source/project/experiment-settings/_callbacks/push_setExpSet_save.m
+++ b/MASH-FRET/source/project/experiment-settings/_callbacks/push_setExpSet_save.m
@@ -79,8 +79,8 @@ end
 if strcmp(dat2import,'sim') || strcmp(dat2import,'video') || ...
         strcmp(dat2import,'trajectories') || strcmp(dat2import,'histogram')
     % add project to list and initialize list indexes
-    proj_id = numel(p.proj)+1;
     p.proj = [p.proj,proj];
+    proj_id = numel(p.proj);
     p.curr_proj = proj_id;
     p = adjustProjIndexLists(p,proj_id,{mod});
 

--- a/MASH-FRET/source/project/setcurrproj.m
+++ b/MASH-FRET/source/project/setcurrproj.m
@@ -1,0 +1,19 @@
+function setcurrproj(h_fig)
+% setcurrproj(h_fig)
+%
+% Get current project index in project list and check whether it is out of
+% range. If yes, the last project in the list is made current and project 
+% list is updated.
+
+% collect interface parameters
+h = guidata(h_fig);
+p = h.param;
+
+% modify current project index if it is out of range of the list
+nProj = numel(p.proj);
+if p.curr_proj>nProj
+    setContPan(['Current project index is out of range: it will now be ',...
+        'set to the last index in list.'],'warning',h_fig);
+    set(h.listbox_projLst,'value',nProj)
+    listbox_projLst_Callback(h.listbox_projLst,[],h_fig);
+end


### PR DESCRIPTION
Project import failures potentially corrupt the index of the current project, giving it a value outside the range of the list. This leads to errors every time a button is pressed, causing the interface to be inoperable.

A first fix attempt is done by setting the current project index after import as the new list's size instead of incrementing it by one. Like so, in case of importing empty projects, the new current project index remains in list's range.
Then, errors are now handled upon button press by resetting the current project index when out of range.

Intends to fix #138.