### PR TITLE
Correct assignment of video dimensions when calculating background trajectories

### DIFF
--- a/MASH-FRET/source/mod-trace-processing/background/calcbgint.m
+++ b/MASH-FRET/source/mod-trace-processing/background/calcbgint.m
@@ -75,7 +75,7 @@ if isCoord && isMov
         else
             fDat{2}{2} = [];
         end
-        fDat{3} = [res_y res_x];
+        fDat{3} = [res_x res_y];
         fDat{4} = viddat_mv{3};
 
         if meth~=6

--- a/MASH-FRET/source/mod-video-processing/graphic-files/readTif_regular.m
+++ b/MASH-FRET/source/mod-video-processing/graphic-files/readTif_regular.m
@@ -79,7 +79,7 @@ if strcmp(n,'all')
             disp(sprintf(str));
         end
 
-        [data,ok] = readTif(fullFname,1,fDat,h_fig,0);
+        [data,ok] = readTif_regular(fullFname,1,fDat,h_fig,0);
         frameCur = data.frameCur;
 
     else


### PR DESCRIPTION
Video width and height were confused when calculating background trajectories, leading to incorrect identification of molecules as being outside image boundaries when video width and height were different.
Video dimension are now correctly assigned.