### PR TITLE
Export Autosort data to text file

### DIFF
--- a/MASH-FRET/source/mod-trace-processing/management/trace-manager/GUI/buildPanelAutoSorting.m
+++ b/MASH-FRET/source/mod-trace-processing/management/trace-manager/GUI/buildPanelAutoSorting.m
@@ -34,7 +34,8 @@ pospan = get(h_pan,'position');
 posfig = get(q.figure_traceMngr,'position');
 wpop = 3*p.wedit+2*p.mg/2;
 wpan = 0.5*wpop + 2*p.wedit + p.wtxt3 + 2.5*p.mg;
-hpan1 = p.mgbig+2*(p.htxt+p.hpop+p.mg/2+p.htxt+p.hedit+p.mg)+p.mg/2+p.hcb;
+hpan1 = p.mgbig+2*(p.htxt+p.hpop+p.mg/2+p.htxt+p.hedit+p.mg)+p.mg/2+p.hcb+...
+    p.mg/2+p.hbut;
 hpan2 = p.mgbig+p.htxt+p.hedit+p.mg+p.htxt+p.mg/2+p.hpop+p.mg/2+p.hpop+...
     p.mg/2+p.htxt+p.mgbig+p.htxt+p.mg+p.hbut+p.mg;
 hpan3 = pospan(4)-2*p.mg-hpan1-p.mg-hpan2-p.mg-2*p.mg;

--- a/MASH-FRET/source/mod-trace-processing/management/trace-manager/GUI/buildPanelData.m
+++ b/MASH-FRET/source/mod-trace-processing/management/trace-manager/GUI/buildPanelData.m
@@ -28,6 +28,7 @@ str9 = 'y max';
 str10 = 'nbins';
 str11 = 'gauss.';
 str12 = 'single count';
+str13 = 'Export to .txt file';
 ttstr0 = wrapHtmlTooltipString('Select the <b>data</b> to represent on <b>the x-axis</b> of the histogram');
 ttstr1 = wrapHtmlTooltipString('Select the <b>value</b> to histogram on the <b>x-axis</b> of the histogram');
 ttstr2 = wrapHtmlTooltipString('<b>Lower</b> bound of <b>x-axis</b>');
@@ -40,6 +41,7 @@ ttstr8 = wrapHtmlTooltipString('<b>Upper</b> bound of <b>y-axis</b>');
 ttstr9 = wrapHtmlTooltipString('<b>Number of binning</b> intervals in <b>y-axis</b>');
 ttstr10 = wrapHtmlTooltipString('<b>Data count:</b> when activated, data values appearing multiple times in the same trajectories are counted once, otherwise it is counted as many times as it appear in each trajectory; single data count allows to scale equally the rapid and slow state interconversions in the TDP.');
 ttstr11 = wrapHtmlTooltipString('<b>Gaussian filter:</b> when activated, the TDP is convoluted with a 2D Gaussian; Gaussian convolution eases the identification of transition clusters.');
+ttstr12 = wrapHtmlTooltipString('<b>Export histogram</b> data to a text file.');
 
 % parent
 h_pan = q.uipanel_data;
@@ -50,6 +52,7 @@ wpop2 = (pospan(3)-2*p.mg-p.mg/fact)/2;
 wedit2 = (pospan(3)-2*p.mg-2*p.mg/fact)/3;
 wcb0 = getUItextWidth(str11,p.fntun,p.fntsz,'normal',p.tbl)+p.wbox;
 wcb1 = pospan(3)-wcb0-2*p.mg;
+wbut = pospan(3)-2*p.mg;
 
 % list strings
 str_pop = getStrPlot_overall(h_fig);
@@ -208,5 +211,13 @@ q.checkbox_AS_datcnt = uicontrol('style','checkbox','parent',h_pan,'units',...
     p.posun,'string',str12,'tooltipstring',ttstr11,'position',...
     [x,y,wcb1,p.hcb],'fontunits',p.fntun,'fontsize',p.fntsz,'enable','off',...
     'callback',{@checkbox_AS_datcnt_Callback,h_fig});
+
+x = p.mg;
+y = y-p.mg/2-p.hbut;
+
+q.push_AS_export = uicontrol('style','pushbutton','parent',h_pan,'units',...
+    p.posun,'string',str13,'tooltipstring',ttstr12,'position',...
+    [x,y,wbut,p.hbut],'fontunits',p.fntun,'fontsize',p.fntsz,'callback',...
+    {@push_AS_export_Callback,h_fig});
 
 

--- a/MASH-FRET/source/mod-trace-processing/management/trace-manager/_callbacks/push_AS_export_Callback.m
+++ b/MASH-FRET/source/mod-trace-processing/management/trace-manager/_callbacks/push_AS_export_Callback.m
@@ -1,0 +1,47 @@
+function push_AS_export_Callback(obj,evd,h_fig)
+
+h = guidata(h_fig);
+p = h.param;
+proj = p.curr_proj;
+projnm = p.proj{proj}.exp_parameters{1,2};
+[fle,loc] = uiputfile('.txt','Enter file name',[projnm,'.txt']);
+[~,flenm,~] = fileparts(fle);
+fle = [loc,flenm,'.txt'];
+
+for chld = h.tm.axes_histSort.Children
+    for c = 1:numel(chld)
+        if ~isprop(chld(c),'Type')
+            continue
+        end
+        switch chld(c).Type
+            case 'histogram'
+                edg = chld(c).BinEdges;
+                x = mean([edg(1:end-1);edg(2:end)],1);
+                cnt = chld(c).BinCounts;
+
+                fhead = 'bin edges\tbin center\tcount\n';
+                fdat = [edg',[x,NaN]',[cnt,NaN]'];
+
+                f = fopen(fle,'Wt');
+                fprintf(f,fhead);
+                fprintf(f,'%d\t%d\t%d\n',fdat');
+                fclose(f);
+        
+                break
+    
+            case 'histogram2'
+                xedg = chld(c).XBinEdges;
+                yedg = chld(c).YBinEdges;
+                x = mean([xedg(1:end-1);xedg(2:end)],1);
+                y = mean([yedg(1:end-1);yedg(2:end)],1);
+                cnt = chld(c).BinCounts; % [nbinx-by-nbiny]
+                fdat = [[NaN;y'],[x;cnt']];
+                save(fle,'fdat','-ascii');
+    
+                break
+    
+            otherwise
+                continue
+        end
+    end
+end


### PR DESCRIPTION
An export button is added to panel **Data** of Trace Manager's Autosort tool. It allows to write 1D or 2D histogram data to a text file.

Thanks to @supazel for requesting this feature.