### PR TITLE
Handle MAC OS with Apple silicon chip

### DIFF
--- a/MASH-FRET/source/divers/mex-compilation/checkMASHmex.m
+++ b/MASH-FRET/source/divers/mex-compilation/checkMASHmex.m
@@ -10,48 +10,21 @@ if exist('forloop','file')~=3
     end
 end
 
-% compile image filters
-% if exist('FilterArray','file')~=3
-%     pname = fileparts(which('FilterArray.c'));
-%     % set runtime library path for LINUX
-%     if strcmp(computer,'GLNXA86') || strcmp(computer,'GLNXA64')
-%         system(['LD_LIBRARY_PATH=$LD_LIBRARY_PATH:',matlabroot,filesep,...
-%             'glnxa64:',matlabroot,filesep,'sys',filesep,'os',filesep,...
-%             'glnxa64']);
-%     end
-%     if strcmp(computer,'PCWIN') || strcmp(computer,'GLNX86') % 32bit OS
-%         runtimefolder = 'runtime32';
-%         libflag = '-lITASL32';
-% 
-%     elseif strcmp(computer,'PCWIN64') || strcmp(computer,'GLNX64') % 64bit OS
-%         runtimefolder = 'runtime64';
-%         libflag = '-lITASL64';
-%     end
-%     cd([pname,filesep,'..',filesep,runtimefolder]);
-%     try
-%         mex('-R2018a',[pname,filesep,'FilterArray.c'],...
-%             ['-L',pname,filesep,'lib'],libflag);
-%     catch err
-%         dispMatlabErr(err);
-%     end
-% end
-
 % compile SIF file import
 if exist('SIFImport','file')~=3
     
-    % libraries unavailable for LINUX
-    if strcmp(computer,'GLNXA86') || strcmp(computer,'GLNXA64') || ...
-            strcmp(computer,'MACI86') || strcmp(computer,'MACI64')
-        disp(['import of old versions of SIF files is not supported ',...
-            'on MacOS and Linux systems']);
+    % libraries unavailable for LINUX and MAC
+    if ~contains(computer,'PCWIN')
+        disp(['import of old versions of SIF files is only supported ',...
+            'on Windows PC systems']);
     else
         pname = fileparts(which('SIFImport.c'));
 
-        if strcmp(computer,'PCWIN') || strcmp(computer,'MACI86') % 32bit OS
+        if strcmp(computer,'PCWIN') % 32bit OS
             runtimefolder = 'runtime32';
             libflag = '-lITASL32';
 
-        elseif strcmp(computer,'PCWIN64') || strcmp(computer,'MACI64') % 64bit OS
+        elseif strcmp(computer,'PCWIN64') % 64bit OS
             runtimefolder = 'runtime64';
             libflag = '-lITASL64';
         end
@@ -68,11 +41,9 @@ end
 % compile SPE file import
 if exist('SPEImport','file')~=3
     
-    % libraries unavailable for LINUX
-    if strcmp(computer,'GLNXA86') || strcmp(computer,'GLNXA64') || ...
-            strcmp(computer,'MACI86') || strcmp(computer,'MACI64')
-        disp(['import of SPE files is not supported on MacOS and Linux ',...
-            'systems']);
+    % libraries unavailable for LINUX and MAC
+    if ~contains(computer,'PCWIN')
+        disp('import of SPE files is only supported on Windows PC systems');
     else
         pname = fileparts(which('SPEImport.c'));
 


### PR DESCRIPTION
The checking of system's OS compatibility before compiling mex files was omitting MAC with Apple silicon chip (MACA64), which was causing an error and prevented MASH from initializing. It is now fixed.

Intends to fix #177 
