### PR TITLE
Handle MATLAB down compatibility

### DIFF
--- a/MASH-FRET/source/mod-trace-processing/plot/plotData.m
+++ b/MASH-FRET/source/mod-trace-processing/plot/plotData.m
@@ -472,9 +472,11 @@ function addleg2plot(varargin)
 for n = 1:nargin
     legdat = varargin{n};
     if ~isempty(legdat{1})
-        legend(legdat{1},legdat{2},'box','on','location','northeast',...
-            'fontsize',6,'iconcolumnwidth',3,'orientation','horizontal',...
-            'backgroundalpha',0.5);
+        leg = legend(legdat{1},legdat{2},'box','on','location','northeast',...
+            'fontsize',6,'orientation','horizontal','backgroundalpha',0.5);
+        if ~isMATLABReleaseOlderThan('R2024b')
+            leg.IconColumnWidth = 3;
+        end
     end
 end
 


### PR DESCRIPTION
Legend property 'IconColumnWidth' was introduced in MATLAB version R2024b. Setting this property when plotting trajectories in Trace processing produced an error when running MASH on older MATLAB versions. User's MATLAB version is now checked prior setting this property.